### PR TITLE
eclipse-962 - add org.fusesource.ide.jmx.local to the features.xml - its...

### DIFF
--- a/features/org.fusesource.ide.runtimes.feature/feature.xml
+++ b/features/org.fusesource.ide.runtimes.feature/feature.xml
@@ -95,6 +95,13 @@ Raleigh NC 27606 USA.
          unpack="false"/>
 
    <plugin
+         id="org.fusesource.ide.jmx.local"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.fusesource.ide.jmx.ui"
          download-size="0"
          install-size="0"


### PR DESCRIPTION
... bundle activator needed for JMX processes view

Since the org.fusesource.ide.jmx.local feature bundle activatir never ran - the local process list was never init'd into the UI.  Simple fix.
