### PR TITLE
eclipse-980 - dont invoke jolokia facade hepler utility with empty user ...

### DIFF
--- a/plugins/org.fusesource.ide.fabric/src/org/fusesource/ide/fabric/views/logs/LogBrowserSupport.java
+++ b/plugins/org.fusesource.ide.fabric/src/org/fusesource/ide/fabric/views/logs/LogBrowserSupport.java
@@ -45,7 +45,7 @@ public abstract class LogBrowserSupport implements ILogBrowser {
 //		System.out.println("Query JSON: " + queryJson);
 
 		String json = filterLogEvents(queryJson);
-		System.out.println("===== JSON: " + json);
+		//System.out.println("===== JSON: " + json);
 		
 		List<LogEventBean> answer = Lists.newArrayList();
 		if (json != null) {
@@ -80,8 +80,12 @@ public abstract class LogBrowserSupport implements ILogBrowser {
 	
 	private String filterLogEvents(String queryJSON) {
 		String result = null;
+		String jUser = getJolokiaUser();
 		
-		JolokiaFabricConnector connector = JolokiaFabricConnector.getFabricConnector(getJolokiaUser(), getJolokiaPassword(), getJolokiaUrl());
+		if (jUser.isEmpty())
+		    return "";
+		
+		JolokiaFabricConnector connector = JolokiaFabricConnector.getFabricConnector(jUser, getJolokiaPassword(), getJolokiaUrl());
 		result = Helpers.execCustomToJSON(connector.getJolokiaClient(),INSIGHT_MBEAN_URL, LOG_QUERY_OPERATION, queryJSON);
 		
 		return result;


### PR DESCRIPTION
...string
Now that logger no longer causes a NPE - this error pops up and repeats every 5 seconds if you select bundle properties and then don't select the input search widget.

!ENTRY org.fusesource.ide.commons 2 2 2013-10-07 16:11:19.713
!MESSAGE Failed to query logs: java.lang.RuntimeException: Failed to call jsonQueryLogResults(java.lang.String) with args: [L
java.lang.Object;@712dba93
!STACK 0
java.lang.RuntimeException: Failed to call jsonQueryLogResults(java.lang.String) with args: [Ljava.lang.Object;@712dba93
at org.fusesource.fabric.jolokia.facade.utils.Helpers.execCustomToJSON(Helpers.java:124)
at org.fusesource.ide.fabric.views.logs.LogBrowserSupport.filterLogEvents(LogBrowserSupport.java:89)
at org.fusesource.ide.fabric.views.logs.LogBrowserSupport.queryLogs(LogBrowserSupport.java:47)
at org.fusesource.ide.fabric.views.logs.LogsView.queryLogs(LogsView.java:212)
at org.fusesource.ide.fabric.views.logs.LogsView$2.run(LogsView.java:93)
at org.eclipse.core.internal.jobs.Worker.run(Worker.java:53)
Caused by: java.lang.IllegalStateException: Target host must not be null, or set in parameters.
at org.apache.http.impl.client.DefaultRequestDirector.determineRoute(DefaultRequestDirector.java:717)
at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:358)
at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:820)
at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:754)
at org.apache.http.impl.client.AbstractHttpClient.execute(AbstractHttpClient.java:732)
at org.jolokia.client.J4pClient.execute(J4pClient.java:155)
at org.jolokia.client.J4pClient.execute(J4pClient.java:103)
at org.fusesource.fabric.jolokia.facade.utils.Helpers.execCustomToJSON(Helpers.java:121)
... 5 more

Don't try filtering the JSON log results with an empty user.
