### PR TITLE
ECLIPSE-1003 - correct lost deploy parameter in hot folder deployment

### DIFF
--- a/plugins/org.fusesource.ide.deployment/src/org/fusesource/ide/deployment/DeploymentContributionItem.java
+++ b/plugins/org.fusesource.ide.deployment/src/org/fusesource/ide/deployment/DeploymentContributionItem.java
@@ -15,7 +15,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.Command;
+import org.eclipse.core.commands.ParameterizedCommand;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jface.action.ContributionItem;
@@ -128,11 +129,13 @@ public class DeploymentContributionItem extends ContributionItem {
 							for (HotfolderDeploymentConfiguration cfg : configs) {
 								if (cfg.isDefaultConfig()) {
 									ICommandService commandService = (ICommandService) PlatformUI.getWorkbench().getService(ICommandService.class);
+									IHandlerService handlerService = (IHandlerService) PlatformUI.getWorkbench().getService(IHandlerService.class);
 									try {
-										HashMap params = new HashMap();
+										HashMap<String, HotfolderDeploymentConfiguration> params = new HashMap<String, HotfolderDeploymentConfiguration>();
 										params.put(DeploymentHandler.DEPLOY_PARAMETER_KEY, cfg);
-										ExecutionEvent evt = new ExecutionEvent(commandService.getCommand(EXECUTE_DEPLOYMENT_ID), params, null, null);
-										commandService.getCommand(EXECUTE_DEPLOYMENT_ID).executeWithChecks(evt);
+										Command command = commandService.getCommand(EXECUTE_DEPLOYMENT_ID);
+										ParameterizedCommand paramCommand = ParameterizedCommand.generateCommand(command, params);
+										handlerService.executeCommand(paramCommand, null);
 										return;
 									} catch (Exception ex) {
 										DeployPlugin.getLogger().error(ex);
@@ -174,11 +177,13 @@ public class DeploymentContributionItem extends ContributionItem {
 				@Override
 				public void widgetSelected(SelectionEvent e) {
 					ICommandService commandService = (ICommandService) PlatformUI.getWorkbench().getService(ICommandService.class);
+					IHandlerService handlerService = (IHandlerService) PlatformUI.getWorkbench().getService(IHandlerService.class);
 					try {
-						HashMap params = new HashMap();
+						HashMap<String, HotfolderDeploymentConfiguration> params = new HashMap<String, HotfolderDeploymentConfiguration>();
 						params.put(DeploymentHandler.DEPLOY_PARAMETER_KEY, cfg);
-						ExecutionEvent evt = new ExecutionEvent(commandService.getCommand(EXECUTE_DEPLOYMENT_ID), params, null, null);
-						commandService.getCommand(EXECUTE_DEPLOYMENT_ID).executeWithChecks(evt);
+						Command command = commandService.getCommand(EXECUTE_DEPLOYMENT_ID);
+						ParameterizedCommand paramCommand = ParameterizedCommand.generateCommand(command, params);
+						handlerService.executeCommand(paramCommand, null);
 					} catch (Exception ex) {
 						DeployPlugin.getLogger().error(ex);
 						throw new RuntimeException("Execution exception occured: " + ex.getMessage());
@@ -289,11 +294,13 @@ public class DeploymentContributionItem extends ContributionItem {
 				@Override
 				public void widgetSelected(SelectionEvent e) {
 					ICommandService commandService = (ICommandService) PlatformUI.getWorkbench().getService(ICommandService.class);
+					IHandlerService handlerService = (IHandlerService) PlatformUI.getWorkbench().getService(IHandlerService.class);
 					try {
-						HashMap params = new HashMap();
+						HashMap<String, HotfolderDeploymentConfiguration> params = new HashMap<String, HotfolderDeploymentConfiguration>();
 						params.put(DeploymentHandler.DEPLOY_PARAMETER_KEY, cfg);
-						ExecutionEvent evt = new ExecutionEvent(commandService.getCommand(EXECUTE_DEPLOYMENT_ID), params, null, null);
-						commandService.getCommand(EXECUTE_DEPLOYMENT_ID).executeWithChecks(evt);
+						Command command = commandService.getCommand(EXECUTE_DEPLOYMENT_ID);
+						ParameterizedCommand paramCommand = ParameterizedCommand.generateCommand(command, params);
+						handlerService.executeCommand(paramCommand, null);
 					} catch (Exception ex) {
 						DeployPlugin.getLogger().error(ex);
 						throw new RuntimeException("Execution exception occured: " + ex.getMessage());

--- a/plugins/org.fusesource.ide.deployment/src/org/fusesource/ide/deployment/handler/DeploymentHandler.java
+++ b/plugins/org.fusesource.ide.deployment/src/org/fusesource/ide/deployment/handler/DeploymentHandler.java
@@ -12,8 +12,13 @@
 package org.fusesource.ide.deployment.handler;
 
 import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.Command;
 import org.eclipse.core.commands.ExecutionEvent;
 import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.core.commands.IParameter;
+import org.eclipse.core.commands.IParameterValues;
+import org.eclipse.core.commands.ParameterValuesException;
+import org.eclipse.core.commands.common.NotDefinedException;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.jdt.core.IJavaElement;
 import org.eclipse.jface.viewers.ISelection;
@@ -36,8 +41,23 @@ public class DeploymentHandler extends AbstractHandler {
 	 */
 	@Override
 	public Object execute(ExecutionEvent event) throws ExecutionException {
-		HotfolderDeploymentConfiguration cfg = (HotfolderDeploymentConfiguration)event.getParameters().get(DEPLOY_PARAMETER_KEY);
+		String configSelection = (String)event.getParameters().get(DEPLOY_PARAMETER_KEY);
+		HotfolderDeploymentConfiguration cfg = null;
+		Command command = event.getCommand();
+		IParameter iParam = null;
+		try {
+			iParam = command.getParameter(DeploymentHandler.DEPLOY_PARAMETER_KEY);
+		} catch (NotDefinedException e1) {
+			throw new ExecutionException("Missing parameter in hot folder deployment. " + e1.getMessage());
+		}
+		IParameterValues vals = null;
+		try {
+			vals = iParam.getValues();
+		} catch (ParameterValuesException e) {
+			throw new ExecutionException("Missing parameter value in hot folder deployment. " + e.getMessage());
+		}
 		
+		cfg = (HotfolderDeploymentConfiguration)vals.getParameterValues().get(configSelection);
 		DeployInNamedContainerAction deployAction = new DeployInNamedContainerAction(cfg);
 		
 		ISelection isel = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getSelectionService().getSelection();
@@ -51,7 +71,6 @@ public class DeploymentHandler extends AbstractHandler {
 			// use the selected file/folder/project as parameter
 			deployAction.launch(isel, "run");	
 		}		
-		
 		return null;
 	}
 }

--- a/plugins/org.fusesource.ide.server.view/src/org/fusesource/ide/server/view/SshView.java
+++ b/plugins/org.fusesource.ide.server.view/src/org/fusesource/ide/server/view/SshView.java
@@ -171,7 +171,6 @@ public class SshView extends TerminalView {
 			fireOnDisconnect();
 			Display.getDefault().syncExec(new Runnable() {
 				
-				@Override
 				public void run() {
 					// clear the console view to make it clear to the user that the connection ended
 					fActionEditClearAll.run();					


### PR DESCRIPTION
Latest kepler has changed the semantics of the HandlerServiceHandler.  Ref:

https://bugs.eclipse.org/bugs/show_bug.cgi?id=413112

Comment from Eclipse Platform UI development team:

"This isn't really the supported way of executing anything in the system.  At best you're executing WorkbenchHandlerServiceHandler directly, and that can do whatever it wants with the ExecutionEvent.

However ... if you go command.executeWithChecks(executionEvent) that's supposed to work (although even that's not recommended, as the correct way to use the system is handlerService.executeCommand(command, null);) and we should look into that."

Modified fuse deployment code to use handlerService.execute as recommended.  Modified the handler code to match.
