### PR TITLE
ECLIPSE-1013 - update vendor/branding to JBoss by Red Hat

### DIFF
--- a/features/org.fusesource.ide.camel.editor.feature/feature.xml
+++ b/features/org.fusesource.ide.camel.editor.feature/feature.xml
@@ -3,7 +3,7 @@
       id="org.fusesource.ide.camel.editor.feature"
       label="JBoss Fuse Camel Editor Feature"
       version="7.2.0.qualifier"
-      provider-name="Red Hat Inc."
+      provider-name="JBoss by Red Hat"
       plugin="org.fusesource.ide.tooling">
 
    <description url="http://fusesource.com/products/fuse-ide/">

--- a/features/org.fusesource.ide.runtimes.feature/feature.xml
+++ b/features/org.fusesource.ide.runtimes.feature/feature.xml
@@ -3,7 +3,7 @@
       id="org.fusesource.ide.runtimes.feature"
       label="JBoss Fuse Runtimes Feature"
       version="7.2.0.qualifier"
-      provider-name="Red Hat Inc."
+      provider-name="JBoss by Red Hat"
       plugin="org.fusesource.ide.tooling">
 
    <description url="http://fusesource.com/products/fuse-ide/">

--- a/features/org.fusesource.ide.server.extensions.feature/feature.xml
+++ b/features/org.fusesource.ide.server.extensions.feature/feature.xml
@@ -3,7 +3,7 @@
       id="org.fusesource.ide.server.extensions.feature"
       label="JBoss Fuse Server Extension Feature"
       version="7.2.0.qualifier"
-      provider-name="Red Hat Inc."
+      provider-name="JBoss by Red Hat"
       plugin="org.fusesource.ide.tooling">
 
    <description url="http://fusesource.com/products/fuse-ide/">

--- a/plugins/org.fusesource.ide.branding/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.branding/OSGI-INF/l10n/bundle.properties
@@ -27,5 +27,5 @@ project.wizard.project.description = Create a new Fuse Project using the Maven b
 rider.preferences.label=Fuse Tooling
 
 remote.description = Fuse Tooling Remote Archetype Catalog
-Bundle-Vendor = Red Hat, Inc.
+Bundle-Vendor = JBoss by Red Hat
 Bundle-Name = Fuse Branding Plugin

--- a/plugins/org.fusesource.ide.camel.editor/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.camel.editor/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Camel Editor Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.camel.editor;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.camel.editor.Activator
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.fusesource.ide.camel.model,
  org.fusesource.ide.commons,
  org.fusesource.ide.graph,

--- a/plugins/org.fusesource.ide.camel.editor/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.camel.editor/OSGI-INF/l10n/bundle.properties
@@ -19,3 +19,6 @@ rider.editor.dtp.name=Camel Context DTP
 rider.editor.dtp.description=Camel Context Diagram Type Provider
 camel.menu.label=Routes
 camel.menu.tooltip=Route specific actions
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Camel Editor Plugin

--- a/plugins/org.fusesource.ide.camel.model/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.camel.model/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Model Plugin
 Bundle-SymbolicName: org.fusesource.ide.camel.model;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Export-Package: org.fusesource.ide.camel.model;
   uses:="org.apache.camel.model,

--- a/plugins/org.fusesource.ide.catalogs/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.catalogs/META-INF/MANIFEST.MF
@@ -3,6 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Catalogs Plugin
 Bundle-SymbolicName: org.fusesource.ide.catalogs;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.wst.xml.core

--- a/plugins/org.fusesource.ide.cheatsheets/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.cheatsheets/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Cheat Sheets Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.cheatsheets;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui.cheatsheets
 Bundle-ActivationPolicy: lazy

--- a/plugins/org.fusesource.ide.cheatsheets/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.cheatsheets/OSGI-INF/l10n/bundle.properties
@@ -8,3 +8,6 @@
 # Contributors:
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Cheat Sheets Plugin

--- a/plugins/org.fusesource.ide.commons/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.commons/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Commons Plugin
 Bundle-SymbolicName: org.fusesource.ide.commons;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.fabric.camel-tooling-util,
  org.fusesource.ide.preferences,

--- a/plugins/org.fusesource.ide.deployment/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.deployment/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Deployment Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.deployment;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.preferences,
  org.fusesource.ide.commons,

--- a/plugins/org.fusesource.ide.deployment/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.deployment/OSGI-INF/l10n/bundle.properties
@@ -22,3 +22,6 @@ deployer.name=Deploy To Container
 deployer.tabgroup.description=Deploy To Container 
 deployer.shortcut.label = Deploy To Container 
 deploy.popup.label = Run in Default Container 
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Deployment Plugin

--- a/plugins/org.fusesource.ide.fabric.activemq/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.fabric.activemq/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Fabric ActiveMQ Facade Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.fabric.activemq;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.fabric,
  org.fusesource.ide.graph,

--- a/plugins/org.fusesource.ide.fabric.activemq/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.fabric.activemq/OSGI-INF/l10n/bundle.properties
@@ -22,3 +22,6 @@ deployer.name=Deploy To Container
 deployer.tabgroup.description=Deploy To Container 
 deployer.shortcut.label = Deploy To Container 
 deploy.popup.label = Run in Default Container 
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Fabric ActiveMQ Facade Plugin

--- a/plugins/org.fusesource.ide.fabric.camel/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.fabric.camel/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Fabric Camel Facade Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.fabric.camel;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.fabric,
  org.fusesource.fabric.camel-tooling-util,

--- a/plugins/org.fusesource.ide.fabric.camel/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.fabric.camel/OSGI-INF/l10n/bundle.properties
@@ -22,3 +22,6 @@ deployer.name=Deploy To Container
 deployer.tabgroup.description=Deploy To Container 
 deployer.shortcut.label = Deploy To Container 
 deploy.popup.label = Run in Default Container 
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Fabric Camel Facade Plugin

--- a/plugins/org.fusesource.ide.fabric.servicemix/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.fabric.servicemix/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Fabric Servicemix Facade Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.fabric.servicemix;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.fabric,
  org.fusesource.ide.preferences,

--- a/plugins/org.fusesource.ide.fabric.servicemix/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.fabric.servicemix/OSGI-INF/l10n/bundle.properties
@@ -22,3 +22,6 @@ deployer.name=Deploy To Container
 deployer.tabgroup.description=Deploy To Container 
 deployer.shortcut.label = Deploy To Container 
 deploy.popup.label = Run in Default Container 
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Fabric Servicemix Facade Plugin

--- a/plugins/org.fusesource.ide.fabric/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.fabric/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Fabric Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.fabric;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.fabric.tooling-jclouds-all,
  org.fusesource.fabric.tooling-fabric-all,

--- a/plugins/org.fusesource.ide.fabric/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.fabric/OSGI-INF/l10n/bundle.properties
@@ -29,3 +29,6 @@ tabgroup.build.description = Build
 
 profile.deleteRequirementsTitle = Delete
 profile.deleteRequirementsText = Deletes the selected profile requirement(s)
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Fabric Plugin

--- a/plugins/org.fusesource.ide.graph/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.graph/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Graph Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.graph;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.osgi,
  org.eclipse.osgi.services,

--- a/plugins/org.fusesource.ide.graph/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.graph/OSGI-INF/l10n/bundle.properties
@@ -8,3 +8,6 @@
 # Contributors:
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Graph Plugin

--- a/plugins/org.fusesource.ide.help/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.help/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Bundle-Version: 7.2.0.qualifier
 Bundle-Name: Fuse Help Plugin
 Bundle-SymbolicName: org.fusesource.ide.help;singleton:=true
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-ManifestVersion: 2
 Bundle-ClassPath: .
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6

--- a/plugins/org.fusesource.ide.jmx.core/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.jmx.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-Name: Fuse JMX Core Plugin
 Bundle-SymbolicName: org.fusesource.ide.jmx.core;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.jmx.core.JMXActivator
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.fusesource.ide.commons,
  org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/plugins/org.fusesource.ide.jmx.local/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.jmx.local/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse JMX Local Plugin
 Bundle-SymbolicName: org.fusesource.ide.jmx.local;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.eclipse.core.resources,
  org.eclipse.core.runtime,
  org.eclipse.ui,

--- a/plugins/org.fusesource.ide.jmx.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.jmx.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: Fuse JMX UI Plugin
 Bundle-SymbolicName: org.fusesource.ide.jmx.ui;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.jmx.ui.JMXUIActivator
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Require-Bundle: org.fusesource.ide.deployment,
  org.fusesource.ide.commons,
  org.fusesource.ide.jmx.core,

--- a/plugins/org.fusesource.ide.launcher.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.launcher.ui/OSGI-INF/l10n/bundle.properties
@@ -9,7 +9,7 @@
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
 Bundle-Name=Fuse Launcher UI Plugin
-Bundle-Vendor=Red Hat, Inc.
+Bundle-Vendor = JBoss by Red Hat
 tabgroup.camelContext.description=Update the settings for running the Camel context locally...
 launcher.tab.camelcontext.name=Camel Context
 launchShortCut.camelContext.label=Local Camel Context

--- a/plugins/org.fusesource.ide.launcher/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.launcher/OSGI-INF/l10n/bundle.properties
@@ -9,7 +9,7 @@
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
 Bundle-Name=Fuse Launcher Plugin
-Bundle-Vendor=Red Hat, Inc.
+Bundle-Vendor = JBoss by Red Hat
 launcher.camelcontext.name=Local Camel Context
 launcher.camelcontext.notests.name=Local Camel Context (without tests)
 launcher.fuseide.category.name=Fuse

--- a/plugins/org.fusesource.ide.maven/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.maven/OSGI-INF/l10n/bundle.properties
@@ -8,5 +8,5 @@
 # Contributors:
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
-Bundle-Vendor = Red Hat, Inc.
+Bundle-Vendor = JBoss by Red Hat
 Bundle-Name = Fuse Maven Plugin

--- a/plugins/org.fusesource.ide.preferences/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.preferences/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Preferences Plugin
 Bundle-SymbolicName: org.fusesource.ide.preferences;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,

--- a/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Project Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.project;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.commons,
  org.fusesource.ide.branding,

--- a/plugins/org.fusesource.ide.project/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.project/OSGI-INF/l10n/bundle.properties
@@ -20,3 +20,6 @@ rider.launcher.delegate.name=Fuse Developer Launcher
 rider.launcher.delegate.description=Launches a new Camel instance with the context/route deployed.
 rider.project.launch.shortcut.run.label=Camel Context
 rider.project.launch.shortcut.run.description=Runs the selected context file in a local Camel instance.
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Project Plugin

--- a/plugins/org.fusesource.ide.server.fuse.core/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.fuse.core/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server Core Plugin for Fuse Runtimes
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.fuse.core;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.commons,
  org.fusesource.ide.preferences,

--- a/plugins/org.fusesource.ide.server.fuse.core/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.fuse.core/OSGI-INF/l10n/bundle.properties
@@ -19,3 +19,5 @@ fuseESBServerType_61=JBoss Fuse 6.1 Server
 fuseESBServerDescription_61=Server Definition of JBoss Fuse 6.1
 
 fusesource=JBoss Fuse
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server Core Plugin for Fuse Runtimes

--- a/plugins/org.fusesource.ide.server.fuse.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.fuse.ui/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server UI Plugin for Fuse Runtimes
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.fuse.ui;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.server.fuse.ui.FuseESBUIPlugin
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.fusesource.ide.server.karaf.core,
  org.fusesource.ide.server.karaf.ui,
  org.fusesource.ide.server.fuse.core,

--- a/plugins/org.fusesource.ide.server.fuse.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.fuse.ui/OSGI-INF/l10n/bundle.properties
@@ -9,3 +9,6 @@
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
 cxfport.pref.name = ESB
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server UI Plugin for Fuse Runtimes

--- a/plugins/org.fusesource.ide.server.karaf.core/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.karaf.core/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server Core Plugin for Apache Karaf
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.karaf.core;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.commons,
  org.fusesource.ide.preferences,

--- a/plugins/org.fusesource.ide.server.karaf.core/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.karaf.core/OSGI-INF/l10n/bundle.properties
@@ -28,3 +28,5 @@ karafServerDescription_23=Server Definition of Apache Karaf 2.3
 
 karaf.launch.name=Fuse Launcher
 fusesource=JBoss Fuse
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server Core Plugin for Apache Karaf

--- a/plugins/org.fusesource.ide.server.karaf.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.karaf.ui/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server UI Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.karaf.ui;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.server.karaf.ui.KarafUIPlugin
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.fusesource.ide.server.karaf.core,
  org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/plugins/org.fusesource.ide.server.karaf.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.karaf.ui/OSGI-INF/l10n/bundle.properties
@@ -9,3 +9,6 @@
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
 cxfport.pref.name = ESB
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server UI Plugin

--- a/plugins/org.fusesource.ide.server.servicemix.core/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.servicemix.core/META-INF/MANIFEST.MF
@@ -1,9 +1,9 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server Core Plugin for Apache ServiceMix
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.servicemix.core;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.commons,
  org.fusesource.ide.preferences,

--- a/plugins/org.fusesource.ide.server.servicemix.core/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.servicemix.core/OSGI-INF/l10n/bundle.properties
@@ -35,3 +35,5 @@ serviceMixServerType_45=Apache ServiceMix 4.5 Server
 serviceMixServerDescription_45=Server Definition of Apache ServiceMix 4.5
 
 fusesource=JBoss Fuse
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server Core Plugin for Apache ServiceMix

--- a/plugins/org.fusesource.ide.server.servicemix.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.servicemix.ui/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server UI Plugin for Apache ServiceMix
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.servicemix.ui;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.server.servicemix.ui.ServiceMixUIPlugin
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.fusesource.ide.server.karaf.core,
  org.fusesource.ide.server.karaf.ui,
  org.fusesource.ide.server.servicemix.core,

--- a/plugins/org.fusesource.ide.server.servicemix.ui/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.servicemix.ui/OSGI-INF/l10n/bundle.properties
@@ -9,3 +9,6 @@
 #     JBoss by Red Hat - Initial implementation.
 ##############################################################################
 cxfport.pref.name = ESB
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server UI Plugin for Apache ServiceMix

--- a/plugins/org.fusesource.ide.server.view/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.server.view/META-INF/MANIFEST.MF
@@ -1,10 +1,10 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
-Bundle-Name: Fuse Server View Plugin
+Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.fusesource.ide.server.view;singleton:=true
 Bundle-Version: 7.2.0.qualifier
 Bundle-Activator: org.fusesource.ide.server.view.ServerViewPlugin
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: %Bundle-Vendor
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,
  org.eclipse.tm.terminal;bundle-version="3.1.1",

--- a/plugins/org.fusesource.ide.server.view/OSGI-INF/l10n/bundle.properties
+++ b/plugins/org.fusesource.ide.server.view/OSGI-INF/l10n/bundle.properties
@@ -10,3 +10,6 @@
 ##############################################################################
 cxfport.pref.name = ESB
 karaf.shell.label=Shell
+
+Bundle-Vendor = JBoss by Red Hat
+Bundle-Name = Fuse Server View Plugin

--- a/plugins/org.fusesource.ide.tooling/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.tooling/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: JBoss Fuse Tooling for Eclipse
 Bundle-SymbolicName: org.fusesource.ide.tooling
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime

--- a/plugins/org.fusesource.ide.zk.core/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.zk.core/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse ZooKeeper Core Plugin
 Bundle-SymbolicName: org.fusesource.ide.zk.core;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.fabric.tooling-fabric-all,
  org.fusesource.fabric.tooling-jclouds-all,

--- a/plugins/org.fusesource.ide.zk.jmx/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.zk.jmx/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse ZK JMX Plugin
 Bundle-SymbolicName: org.fusesource.ide.zk.jmx;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.zk.core,
  org.fusesource.fabric.tooling-fabric-all,

--- a/plugins/org.fusesource.ide.zk.zookeeper/META-INF/MANIFEST.MF
+++ b/plugins/org.fusesource.ide.zk.zookeeper/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse ZooKeeper Plugin
 Bundle-SymbolicName: org.fusesource.ide.zk.zookeeper;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.fusesource.ide.zk.core,
  org.fusesource.ide.zk.jmx,

--- a/plugins/rcp_build/org.fusesource.ide.rcp.branding/OSGI-INF/l10n/bundle.properties
+++ b/plugins/rcp_build/org.fusesource.ide.rcp.branding/OSGI-INF/l10n/bundle.properties
@@ -13,7 +13,7 @@ project.wizard.project.description = Create a new Fuse Project using the Maven b
 rider.preferences.label=Fuse IDE
 
 remote.description = Fuse IDE Remote Archetype Catalog
-Bundle-Vendor = Red Hat, Inc.
+Bundle-Vendor = JBoss by Red Hat
 Bundle-Name = Fuse IDE Branding Plugin
 
 productName=Fuse IDE

--- a/tests/org.fusesource.ide.camel.editor.tests/META-INF/MANIFEST.MF
+++ b/tests/org.fusesource.ide.camel.editor.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Plugins for Eclipse Camel Editor Plugin Tests
 Bundle-SymbolicName: org.fusesource.ide.camel.editor.tests;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.fusesource.ide.camel.model
 Require-Bundle: org.junit

--- a/tests/org.fusesource.ide.camel.model.tests/META-INF/MANIFEST.MF
+++ b/tests/org.fusesource.ide.camel.model.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Plugins for Eclipse Model Plugin Tests
 Bundle-SymbolicName: org.fusesource.ide.camel.model.tests;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.fusesource.ide.camel.model
 Require-Bundle: org.junit,

--- a/tests/org.fusesource.ide.fabric.tests/META-INF/MANIFEST.MF
+++ b/tests/org.fusesource.ide.fabric.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Fabric Plugin Tests
 Bundle-SymbolicName: org.fusesource.ide.fabric.tests;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.fusesource.ide.fabric
 Require-Bundle: org.junit

--- a/tests/org.fusesource.ide.maven.tests/META-INF/MANIFEST.MF
+++ b/tests/org.fusesource.ide.maven.tests/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: Fuse Plugins for Eclipse Maven Plugin Tests
 Bundle-SymbolicName: org.fusesource.ide.maven.tests;singleton:=true
 Bundle-Version: 7.2.0.qualifier
-Bundle-Vendor: Red Hat, Inc.
+Bundle-Vendor: JBoss by Red Hat
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Fragment-Host: org.fusesource.ide.maven
 Require-Bundle: org.junit


### PR DESCRIPTION
Modified features and plugins meta-data to consistently use "JBoss by Red Hat".  I used the localization directory if one existed (make translation a little easier later).  If no l10n folder existed I just changed the MANIFEST.  I did not change anything on the runtime side.
