### PR TITLE
fusetools-1052 - correct feature dependencies

### DIFF
--- a/features/org.fusesource.ide.camel.editor.feature/feature.xml
+++ b/features/org.fusesource.ide.camel.editor.feature/feature.xml
@@ -254,4 +254,60 @@ Raleigh NC 27606 USA.
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.springframework.aop"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.asm"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.beans"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.context"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.context.support"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.expression"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.springframework.transaction"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/features/org.fusesource.ide.runtimes.feature/feature.xml
+++ b/features/org.fusesource.ide.runtimes.feature/feature.xml
@@ -264,6 +264,13 @@ Raleigh NC 27606 USA.
          unpack="false"/>
 
    <plugin
+         id="org.joda.time"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="com.google.guava"
          download-size="0"
          install-size="0"

--- a/plugins/org.fusesource.ide.catalogs/build.properties
+++ b/plugins/org.fusesource.ide.catalogs/build.properties
@@ -2,5 +2,4 @@ source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml,\
-               xsd/
+               plugin.xml

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
   <!--  <slf4j-version>1.7.0</slf4j-version> -->
     <drools.updatesite.version>6.0.0.201304021236</drools.updatesite.version>
     
-    <spring3-version>3.1.3.RELEASE</spring3-version>
+    <spring3-version>3.1.4.RELEASE</spring3-version>
     <scala.library.version>${scala-version}</scala.library.version>
     <aries-version>${aries-blueprint-version}</aries-version>
     <aries-quiesce-version>1.0.0</aries-quiesce-version>
@@ -432,6 +432,11 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context-support</artifactId>
+      <version>${spring3-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
       <version>${spring3-version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
This gets the fuse tooling to complete installation but the Fuse Integration perspective doesn't appear in the Perspectives pulldown menu.  I can get the Fuse Integration perspective to run from a debug session - need to investigate more.
