### PR TITLE
Bz1031156

### DIFF
--- a/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/EditorMessages.java
+++ b/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/EditorMessages.java
@@ -80,7 +80,9 @@ public class EditorMessages extends NLS {
 
 	public static String camelMenuLabel;
 	public static String camelMenuAddLabel;
-
+	
+	public static String switchyardFoundTitle;
+	public static String switchyardFoundText;
 
 	static {
 		// initialize resource bundle

--- a/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/editor/RiderDesignEditor.java
+++ b/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/editor/RiderDesignEditor.java
@@ -1078,6 +1078,11 @@ public class RiderDesignEditor extends DiagramEditor implements INodeViewer, IDe
 	public void loadModelFromFile(IFile file) throws IOException, PartInitException {
 		editor.onFileLoading(file);
 		this.setModel(data.marshaller.loadRoutes(file));
+		if (file.getName().contentEquals("switchyard.xml")) {
+			MessageDialog.openWarning(getSite().getShell(), EditorMessages.switchyardFoundTitle,
+					EditorMessages.switchyardFoundText);
+			switchToSourceEditor();
+		}
 		ValidationHandler status = this.getModel().validate();
 		if (status.hasErrors()) {
 			switchToSourceEditor();

--- a/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/l10n/editorMessages.properties
+++ b/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/l10n/editorMessages.properties
@@ -63,5 +63,8 @@ colorPreferencePageFigureBGColorSetting=Route Editor Diagram Figure Background
 colorPreferencePageFigureFGColorSetting=Route Editor Diagram Figure Foreground
 colorPreferencePageTableChartBGColorSetting=Numeric Column Bar Chart Color
 
+switchyardFoundTitle=SwitchYard XML file detected
+switchyardFoundText=Please select a different XML editor - source editing only supported in this mode.
+
 camelMenuLabel=Routes
 camelMenuAddLabel = Add

--- a/plugins/org.fusesource.ide.camel.model/src/org/fusesource/ide/camel/model/io/XmlContainerMarshaller.java
+++ b/plugins/org.fusesource.ide.camel.model/src/org/fusesource/ide/camel/model/io/XmlContainerMarshaller.java
@@ -38,9 +38,6 @@ public class XmlContainerMarshaller extends ContainerMarshallerSupport {
 	@Override
 	public RouteContainer loadRoutes(File file) {
 		try {
-			if (file.getName().contentEquals("switchyard.xml"))
-				throw new Exception("SwitchYard XML file detected.");
-			
 			RouteXml helper = createXmlHelper();
 			Activator.getLogger().debug("Loading file: " + file);
 			XmlModel model = helper.unmarshal(file);
@@ -72,11 +69,11 @@ public class XmlContainerMarshaller extends ContainerMarshallerSupport {
 		if (model.contextElement() != null && model.contextElement().getId() != null) {
 			id = model.contextElement().getId();
 		} else {
-			if (model.node().isEmpty()) {
-				Exception e = new Exception("Unable to determine route container, no node detected.");
-				Activator.getLogger().warning(e);
-				throw new RuntimeException(e);
-			}
+            if (model.node().isEmpty()) {
+               Exception e = new Exception("Unable to determine route container, no node detected.");
+               Activator.getLogger().warning(e);
+               throw new RuntimeException(e);
+            }			
 			Element e = (Element)model.node().get();
 			Attribute a = e.getAttribute("id");
 			if (a != null) id = a.getValue();


### PR DESCRIPTION
Couldn't eliminate the fuse camel route editor from the workbench/ project explorer pull-down since it was registered by supported extension (xml) and the OpenWithMenu method was not extendable.  No other supported was to exclude a partucular file.  Consequently - added a check to the RiderDesignEditor to issue a warning if it encounters a 'switchyard.xml' file and then default to the source editor (design editor is always empty).  The source editor will work.
