### PR TITLE
fusetools-1205 - create a seperate independently installable update site...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,10 @@
 
   <properties>
     <!-- JBoss Tools Integration Stack version -->
-    <jbtis.version>4.2.0.Beta1</jbtis.version>
+    <jbtis.version>4.2.0.Beta1b</jbtis.version>
     
     <!-- Tycho version -->
-    <jboss-tycho-version>${tychoVersion}</jboss-tycho-version>
+    <jboss-tycho-version>0.21.1</jboss-tycho-version>
     
     <!-- fuse tooling related versions -->
     <tycho.scmUrl>scm:git:https://github.com/fusesource/fuseide.git</tycho.scmUrl>

--- a/site/pom.xml
+++ b/site/pom.xml
@@ -19,7 +19,6 @@
 	  <update.site.name>JBoss Fuse Tooling</update.site.name>
 	  <update.site.description>Nightly Build</update.site.description>
 	  <update.site.version>${project.version}.${BUILD_ALIAS}</update.site.version>
-<!--	  <target.eclipse.version>4.3 (Kepler)</target.eclipse.version>  -->
 	  <target.eclipse.version>4.4 (Luna)</target.eclipse.version>
 	  <siteTemplateFolder>siteTemplateFolder</siteTemplateFolder>
 	</properties>
@@ -39,10 +38,10 @@
 		    <goal>generate-repository-facade</goal>
 		  </goals>
 		  <configuration>
+		    <referenceStrategy>compositeReferences</referenceStrategy>
 		    <associateSites>
-		      <associateSite>http://download.jboss.org/jbosstools/updates/stable/luna/</associateSite>
+		      <associateSite>http://download.jboss.org/jbosstools/updates/development/luna/</associateSite>
 		      <associateSite>http://download.jboss.org/jbosstools/targetplatforms/jbtistarget/luna/</associateSite>
-		      <associateSite>http://download.jboss.org/jbosstools/updates/requirements/gemini/2.0.0.RELEASE/</associateSite>
 		    </associateSites>
 
 		    <siteTemplateFolder>${siteTemplateFolder}</siteTemplateFolder>


### PR DESCRIPTION
... - update JBTIS TP to 4.2.0.Beta1b

The generated org.fusesource.ide.updatesite-7.3.0-SNAPSHOT.zip can not be installed unless JBTIS was installed first.  If you unzip the update site you'll see repository/withreferences composite directory.  That may be installed independently (right into a fresh eclipse instance).  The live update site will have the repository/withreferences directory available for independent QE installs.
