### PR TITLE
Fixes #252: Add validation for field and variable mappings

### DIFF
--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/TransformationEditor.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/TransformationEditor.java
@@ -367,18 +367,10 @@ public class TransformationEditor extends EditorPart implements ISaveablePart2 {
                         public boolean validateDrop(final Object target,
                                                     final int operation,
                                                     final TransferData transferType) {
-                            final Object source =
-                                ((IStructuredSelection)LocalSelectionTransfer.getTransfer()
-                                                                             .getSelection())
-                                                                             .getFirstElement();
-                            if (source instanceof Model && target instanceof Model) {
-                                return getCurrentLocation() == ViewerDropAdapter.LOCATION_ON
-                                       && Util.draggingFromValidSource(config)
-                                       && (Util.dragDropComboIsValid((Model)source,
-                                                                     (Model)target) == null);
-                            }
                             return getCurrentLocation() == ViewerDropAdapter.LOCATION_ON
-                                   && Util.draggingFromValidSource(config);
+                                   && Util.draggingFromValidSource(config)
+                                   && Util.validSourceAndTarget(Util.draggedObject(),
+                                                                            target);
                         }
                     });
                     potentialDropTargets.add(new PotentialDropTarget(treeViewer.getTree()) {

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/MappingDetailViewer.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/MappingDetailViewer.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.eclipse.jface.dialogs.IDialogConstants;
-import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.viewers.ArrayContentProvider;
@@ -336,11 +335,6 @@ public final class MappingDetailViewer extends MappingViewer {
      * @param mapping
      */
     public void update(final MappingOperation<?, ?> mapping) {
-        if (mapping.getSource() instanceof Model && mapping.getTarget() instanceof Model) {
-            if (Util.dragDropComboIsValid((Model) mapping.getSource(), (Model) mapping.getTarget()) != null) {
-                return;
-            }
-        }
         this.mapping = mapping;
         if (sourceDropTarget != null) dispose();
         final Composite contentPane = new Composite(scroller, SWT.NONE);
@@ -606,28 +600,14 @@ public final class MappingDetailViewer extends MappingViewer {
         }
 
         void validate() {
-            String message = null;
-            // are we looking at the target side of the equation?
-            if (field != null && !rootModel.equals(config.getSourceModel())) {
-                if (mapping.getSource() instanceof Model) {
-                    message = Util.dragDropComboIsValid((Model)mapping.getSource(), field);
-                    if (message != null) {
-                        message = "Invalid target."; // override message for now
-                    }
-                }
-            } else {
-                message = Util.dragSourceIsValid(field);
-                if (message != null) {
-                    message = "Invalid source."; // override message for now
-                }
+            boolean enabled = field != null && !Util.type(field);
+            if (enabled) {
+                if (rootModel.equals(config.getSourceModel()))
+                    enabled = Util.validSourceAndTarget(field, mapping.getTarget());
+                else enabled = Util.validSourceAndTarget(mapping.getSource(), field);
             }
-            if (message != null) {
-                this.setMessage(message, IMessageProvider.WARNING);
-            } else {
-                this.setMessage(message());
-            }
-            getButton(IDialogConstants.OK_ID).setEnabled(message == null);
-//            getButton(IDialogConstants.OK_ID).setEnabled(field != null);
+            setErrorMessage(enabled ? null : "Invalid field");
+            getButton(IDialogConstants.OK_ID).setEnabled(enabled);
         }
     }
 

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/MappingSummary.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/MappingSummary.java
@@ -24,10 +24,8 @@ import org.jboss.tools.fuse.transformation.MappingOperation;
 import org.jboss.tools.fuse.transformation.MappingType;
 import org.jboss.tools.fuse.transformation.editor.internal.MappingsViewer.TraversalListener;
 import org.jboss.tools.fuse.transformation.editor.internal.util.TransformationConfig;
-import org.jboss.tools.fuse.transformation.editor.internal.util.Util;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util.Colors;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util.Images;
-import org.jboss.tools.fuse.transformation.model.Model;
 
 final class MappingSummary extends MappingViewer {
 
@@ -120,33 +118,33 @@ final class MappingSummary extends MappingViewer {
         if (eventType.equals(TransformationConfig.MAPPING))
             dispose((MappingOperation<?, ?>) oldValue);
         else if (eventType.equals(TransformationConfig.MAPPING_SOURCE)) {
-            MappingOperation<?, ?> tempMapping = (MappingOperation<?, ?>) newValue;
-            if (tempMapping.getSource() instanceof Model && Util.dragSourceIsValid((Model) tempMapping.getSource()) == null) {
+//            MappingOperation<?, ?> tempMapping = (MappingOperation<?, ?>) newValue;
+//            if (tempMapping.getSource() instanceof Model && Util.dragSourceIsValid((Model) tempMapping.getSource()) == null) {
+//                mapping = (MappingOperation<?, ?>)newValue;
+//                setSourceText();
+//                mappingSourcePane.layout();
+//                sourceText.setFocus();
+//            } else if (tempMapping.getSource() != null && !(tempMapping.getSource() instanceof Model)) {
                 mapping = (MappingOperation<?, ?>)newValue;
                 setSourceText();
                 mappingSourcePane.layout();
                 sourceText.setFocus();
-            } else if (tempMapping.getSource() != null && !(tempMapping.getSource() instanceof Model)) {
-                mapping = (MappingOperation<?, ?>)newValue;
-                setSourceText();
-                mappingSourcePane.layout();
-                sourceText.setFocus();
-            }
+//            }
         } else if (eventType.equals(TransformationConfig.MAPPING_TARGET)) {
-            MappingOperation<?, ?> tempMapping = (MappingOperation<?, ?>) newValue;
-            if (tempMapping.getSource() instanceof Model && tempMapping.getTarget() instanceof Model) {
-                if (Util.dragDropComboIsValid((Model) tempMapping.getSource(), (Model) tempMapping.getTarget()) == null) {
-                    mapping = (MappingOperation<?, ?>)newValue;
-                    setTargetText();
-                    mappingTargetPane.layout();
-                    targetText.setFocus();
-                }
-            } else {
+//            MappingOperation<?, ?> tempMapping = (MappingOperation<?, ?>) newValue;
+//            if (tempMapping.getSource() instanceof Model && tempMapping.getTarget() instanceof Model) {
+//                if (Util.dragDropComboIsValid((Model) tempMapping.getSource(), (Model) tempMapping.getTarget()) == null) {
+//                    mapping = (MappingOperation<?, ?>)newValue;
+//                    setTargetText();
+//                    mappingTargetPane.layout();
+//                    targetText.setFocus();
+//                }
+//            } else {
                 mapping = (MappingOperation<?, ?>)newValue;
                 setTargetText();
                 mappingTargetPane.layout();
                 targetText.setFocus();
-            }
+//            }
         } else if (eventType.equals(TransformationConfig.MAPPING_CUSTOMIZE)) {
             mapping = (MappingOperation<?, ?>)newValue;
             setSourceText();

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/MappingViewer.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/MappingViewer.java
@@ -26,11 +26,11 @@ import org.jboss.tools.fuse.transformation.Expression;
 import org.jboss.tools.fuse.transformation.MappingOperation;
 import org.jboss.tools.fuse.transformation.MappingType;
 import org.jboss.tools.fuse.transformation.Variable;
-import org.jboss.tools.fuse.transformation.model.Model;
 import org.jboss.tools.fuse.transformation.editor.Activator;
 import org.jboss.tools.fuse.transformation.editor.internal.util.TransformationConfig;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util.Colors;
+import org.jboss.tools.fuse.transformation.model.Model;
 
 abstract class MappingViewer {
 
@@ -56,7 +56,9 @@ abstract class MappingViewer {
 
             @Override
             boolean draggingFromValidObject() {
-                return Util.draggingFromValidSource(config);
+                return Util.draggingFromValidSource(config)
+                       && Util.validSourceAndTarget(Util.draggedObject(),
+                                                                mapping.getTarget());
             }
 
             @Override
@@ -69,7 +71,9 @@ abstract class MappingViewer {
             @Override
             public boolean valid() {
                 return mapping.getType() != MappingType.CUSTOM
-                       && Util.draggingFromValidSource(config);
+                       && Util.draggingFromValidSource(config)
+                       && Util.validSourceAndTarget(Util.draggedObject(),
+                               mapping.getTarget());
             }
         });
     }
@@ -83,7 +87,9 @@ abstract class MappingViewer {
 
             @Override
             boolean draggingFromValidObject() {
-                return Util.draggingFromValidTarget(config);
+                return Util.draggingFromValidTarget(config)
+                       && Util.validSourceAndTarget(mapping.getSource(),
+                                                                Util.draggedObject());
             }
 
             @Override
@@ -96,7 +102,9 @@ abstract class MappingViewer {
             @Override
             public boolean valid() {
                 return mapping.getType() != MappingType.CUSTOM
-                       && Util.draggingFromValidTarget(config);
+                       && Util.draggingFromValidTarget(config)
+                       && Util.validSourceAndTarget(mapping.getSource(),
+                                                                Util.draggedObject());
             }
         });
     }

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/TransformationConfig.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/TransformationConfig.java
@@ -87,8 +87,7 @@ public class TransformationConfig implements MapperConfiguration {
     public TransformationConfig(final IFile file,
                                 final URLClassLoader loader) throws Exception {
         this.file = file;
-        this.delegate = DozerMapperConfiguration.loadConfig(new File(file.getLocationURI()),
-                                                            loader);
+        delegate = DozerMapperConfiguration.loadConfig(new File(file.getLocationURI()), loader);
     }
 
     /**
@@ -147,6 +146,16 @@ public class TransformationConfig implements MapperConfiguration {
         return customMapping;
     }
 
+    Model find(final Object object,
+               final Model model) {
+        if (model.equals(object)) return model;
+        for (final Model child : model.getChildren()) {
+            final Model match = find(object, child);
+            if (match != null) return match;
+        }
+        return null;
+    }
+
     private void fireEvent(final String eventType,
                            final Object oldValue,
                            final Object newValue) {
@@ -181,7 +190,119 @@ public class TransformationConfig implements MapperConfiguration {
      */
     @Override
     public List<MappingOperation<?, ?>> getMappings() {
-        final List<MappingOperation<?, ?>> mappings = delegate.getMappings();
+        final List<MappingOperation<?, ?>> mappings = new ArrayList<>();
+        for (final MappingOperation<?, ?> mapping : delegate.getMappings()) {
+            final Model target = find(mapping.getTarget(), delegate.getTargetModel());
+            if (target == null)
+                throw new RuntimeException("Unable to find target model: " + mapping.getTarget());
+            if (mapping.getType() == MappingType.FIELD) {
+                final Model source = find(mapping.getSource(), delegate.getSourceModel());
+                if (source == null)
+                    throw new RuntimeException("Unable to find source model: " + mapping.getSource());
+                mappings.add(new FieldMapping() {
+
+                    @Override
+                    public Model getSource() {
+                        return source;
+                    }
+
+                    @Override
+                    public Model getTarget() {
+                        return target;
+                    }
+
+                    @Override
+                    public MappingType getType() {
+                        return mapping.getType();
+                    }
+                });
+            } else if (mapping.getType() == MappingType.CUSTOM) {
+                final Model source = find(mapping.getSource(), delegate.getSourceModel());
+                if (source == null)
+                    throw new RuntimeException("Unable to find source model: " + mapping.getSource());
+                final CustomMapping customMapping = (CustomMapping)mapping;
+                mappings.add(new CustomMapping() {
+
+                    @Override
+                    public String getMappingClass() {
+                        return customMapping.getMappingClass();
+                    }
+
+                    @Override
+                    public String getMappingOperation() {
+                        return customMapping.getMappingOperation();
+                    }
+
+                    @Override
+                    public Model getSource() {
+                        return source;
+                    }
+
+                    @Override
+                    public Model getTarget() {
+                        return target;
+                    }
+
+                    @Override
+                    public MappingType getType() {
+                        return mapping.getType();
+                    }
+
+                    @Override
+                    public void setMappingClass(final String className) {
+                        customMapping.setMappingClass(className);
+                    }
+
+                    @Override
+                    public void setMappingOperation(final String operationName) {
+                        customMapping.setMappingOperation(operationName);
+                    }
+                });
+            } else if (mapping.getType() == MappingType.VARIABLE) {
+                final VariableMapping variableMapping = (VariableMapping)mapping;
+                mappings.add(new VariableMapping() {
+
+                    @Override
+                    public Variable getSource() {
+                        return variableMapping.getSource();
+                    }
+
+                    @Override
+                    public Model getTarget() {
+                        return target;
+                    }
+
+                    @Override
+                    public MappingType getType() {
+                        return mapping.getType();
+                    }
+
+                    @Override
+                    public void setVariable(final Variable variable) {
+                        variableMapping.setVariable(variable);
+                    }
+                });
+            } else if (mapping.getType() == MappingType.EXPRESSION) {
+                final ExpressionMapping expressionMapping = (ExpressionMapping)mapping;
+                mappings.add(new ExpressionMapping() {
+
+                    @Override
+                    public Expression getSource() {
+                        return expressionMapping.getSource();
+                    }
+
+                    @Override
+                    public Model getTarget() {
+                        return target;
+                    }
+
+                    @Override
+                    public MappingType getType() {
+                        return mapping.getType();
+                    }
+                });
+            }
+        }
         mappings.addAll(mappingPlaceholders);
         return mappings;
     }
@@ -501,7 +622,7 @@ public class TransformationConfig implements MapperConfiguration {
                 }
             } else {
                 if (mapping.getType() != null) delegate.removeMapping(mapping);
-                Expression expression = (Expression)source;
+                final Expression expression = (Expression)source;
                 resultMapping = delegate.mapExpression(expression.getLanguage(),
                                                        expression.getExpression(),
                                                        target);


### PR DESCRIPTION
This contains a temporary hack that ensures validation works correctly when setting or dropping fields in a mapping.
The hack is terribly inefficient, but will be removed once the backend is eventually updated to correct inconsistencies between the models within the config root models vs. those in the mappings.