### PR TITLE
FUSETOOLS-1401: Mapped state of field in target model doesn't get updated after inclusion in expression mapping

### DIFF
--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/ModelTabFolder.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/ModelTabFolder.java
@@ -24,6 +24,7 @@ abstract class ModelTabFolder extends CTabFolder {
 
     final Model model;
 
+    final CTabItem modelTab;
     final ModelViewer modelViewer;
 
     /**
@@ -48,17 +49,17 @@ abstract class ModelTabFolder extends CTabFolder {
         final ToolBar toolBar = new ToolBar(this, SWT.RIGHT);
         setTopRight(toolBar);
 
-        final CTabItem tab = new CTabItem(this, SWT.NONE);
-        tab.setText(title + (model == null ? "" : ": " + model.getName()));
+        modelTab = new CTabItem(this, SWT.NONE);
+        modelTab.setText(title + (model == null ? "" : ": " + model.getName()));
         modelViewer = constructModelViewer(config, potentialDropTargets);
-        tab.setControl(modelViewer);
+        modelTab.setControl(modelViewer);
         modelViewer.setLayoutData(GridDataFactory.fillDefaults().grab(true, true).create());
         modelViewer.layout();
-        setSelection(tab);
+        setSelection(modelTab);
     }
 
-    ModelViewer constructModelViewer(final TransformationConfig config,
-                                               final List<PotentialDropTarget> potentialDropTargets) {
+    ModelViewer constructModelViewer(TransformationConfig config,
+                                     List<PotentialDropTarget> potentialDropTargets) {
         return new ModelViewer(config, this, model, potentialDropTargets);
     }
 
@@ -67,6 +68,7 @@ abstract class ModelTabFolder extends CTabFolder {
      */
     public void select(final Object object) {
         if (object instanceof Model) {
+            setSelection(modelTab);
             modelViewer.select((Model)object);
         }
     }

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/SourceTabFolder.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/SourceTabFolder.java
@@ -10,16 +10,21 @@
 
 package org.jboss.tools.fuse.transformation.editor.internal;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.List;
 
+import org.eclipse.jface.viewers.StructuredSelection;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.CTabItem;
 import org.eclipse.swt.widgets.Composite;
+import org.jboss.tools.fuse.transformation.Variable;
 import org.jboss.tools.fuse.transformation.editor.internal.util.TransformationConfig;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util.Images;
 
 public final class SourceTabFolder extends ModelTabFolder {
 
+    private final CTabItem variablesTab;
     private final VariablesViewer variablesViewer;
 
     public SourceTabFolder(final TransformationConfig config,
@@ -28,10 +33,47 @@ public final class SourceTabFolder extends ModelTabFolder {
         super(config, parent, "Source", config.getSourceModel(), potentialDropTargets);
 
         // Create variables tab
-        final CTabItem variablesTab = new CTabItem(this, SWT.NONE);
+        variablesTab = new CTabItem(this, SWT.NONE);
         variablesTab.setText("Variables");
         variablesViewer = new VariablesViewer(config, this);
         variablesTab.setControl(variablesViewer);
         variablesTab.setImage(Images.VARIABLE);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.tools.fuse.transformation.editor.internal.ModelTabFolder#constructModelViewer(org.jboss.tools.fuse.transformation.editor.internal.util.TransformationConfig, java.util.List)
+     */
+    @Override
+    ModelViewer constructModelViewer(TransformationConfig config,
+            List<PotentialDropTarget> potentialDropTargets) {
+        final ModelViewer viewer = super.constructModelViewer(config, potentialDropTargets);
+        config.addListener(new PropertyChangeListener() {
+
+            @Override
+            public void propertyChange(final PropertyChangeEvent event) {
+                if (event.getPropertyName().equals(TransformationConfig.MAPPING_TARGET)) {
+                    if (!viewer.treeViewer.getControl().isDisposed()) {
+                        viewer.treeViewer.refresh();
+                    }
+                }
+            }
+        });
+        return viewer;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see org.jboss.tools.fuse.transformation.editor.internal.ModelTabFolder#select(java.lang.Object)
+     */
+    @Override
+    public void select(Object object) {
+        super.select(object);
+        if (object instanceof Variable) {
+            setSelection(variablesTab);
+            variablesViewer.tableViewer.setSelection(new StructuredSelection(object), true);
+        }
     }
 }

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/TargetTabFolder.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/TargetTabFolder.java
@@ -10,6 +10,8 @@
 
 package org.jboss.tools.fuse.transformation.editor.internal;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.List;
 
 import org.eclipse.jface.util.LocalSelectionTransfer;
@@ -117,6 +119,17 @@ public final class TargetTabFolder extends ModelTabFolder {
             @Override
             public boolean valid() {
                 return Util.draggingFromValidSource(config);
+            }
+        });
+        config.addListener(new PropertyChangeListener() {
+
+            @Override
+            public void propertyChange(final PropertyChangeEvent event) {
+                if (event.getPropertyName().equals(TransformationConfig.MAPPING_TARGET)) {
+                    if (!modelViewer.treeViewer.getControl().isDisposed()) {
+                        modelViewer.treeViewer.refresh();
+                    }
+                }
             }
         });
         return modelViewer;


### PR DESCRIPTION
Also changed so that selecting an existing variable mapping selects the variables tab and applicable variable in the source tab folder.