### PR TITLE
FUSETOOLS-1453 - making XML picker a bit smarter

### DIFF
--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/.classpath
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/.classpath
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
+	<classpathentry exported="true" kind="lib" path="libs/jaxb-impl-2.2.6.jar"/>
 	<classpathentry exported="true" kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src/main/java/"/>
 	<classpathentry kind="src" path="src/main/resources/"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry exported="true" kind="lib" path="libs/data-transform-common-8.0.0-SNAPSHOT.jar" sourcepath="/data-transform-common"/>
-    <classpathentry exported="true" kind="lib" path="libs/jaxb-xjc-2.2.6.jar"/>
+	<classpathentry exported="true" kind="lib" path="libs/jaxb-xjc-2.2.6.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/META-INF/MANIFEST.MF
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/META-INF/MANIFEST.MF
@@ -29,4 +29,5 @@ Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %Bundle-Vendor
 Bundle-ClassPath: .,
  libs/data-transform-common-8.0.0-SNAPSHOT.jar,
- libs/jaxb-xjc-2.2.6.jar
+ libs/jaxb-xjc-2.2.6.jar,
+ libs/jaxb-impl-2.2.6.jar

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/build.properties
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/build.properties
@@ -8,5 +8,6 @@ bin.includes = META-INF/,\
                libs/,\
                libs/data-transform-common-8.0.0-SNAPSHOT.jar,\
                libs/jaxb-xjc-2.2.6.jar,\
-               icons/
+               icons/,\
+               libs/jaxb-impl-2.2.6.jar
                

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/pom.xml
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/pom.xml
@@ -57,6 +57,10 @@
                             <groupId>com.sun.xml.bind</groupId>
                             <artifactId>jaxb-xjc</artifactId>
                         </artifactItem>
+                        <artifactItem>
+                            <groupId>com.sun.xml.bind</groupId>
+                            <artifactId>jaxb-impl</artifactId>
+                        </artifactItem>
                     </artifactItems>
                 </configuration>
             </plugin>

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ClasspathXMLResourceSelectionDialog.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ClasspathXMLResourceSelectionDialog.java
@@ -1,0 +1,92 @@
+/******************************************************************************
+ * Copyright (c) 2015 Red Hat, Inc. and others. 
+ * All rights reserved. This program and the accompanying materials are 
+ * made available under the terms of the Eclipse Public License v1.0 which 
+ * accompanies this distribution, and is available at 
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors: JBoss by Red Hat - Initial implementation.
+ *****************************************************************************/
+package org.jboss.tools.fuse.transformation.editor.internal.util;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.swt.widgets.Shell;
+import org.fusesource.ide.commons.contenttype.FindNamespaceHandlerSupport;
+import org.fusesource.ide.commons.contenttype.XmlMatchingStrategySupport;
+import org.fusesource.ide.commons.util.IFiles;
+import org.xml.sax.InputSource;
+
+/**
+ * Present a file chooser dialog that only lists those files that are on
+ * the classpath and are XML based (i.e. can be parsed by the SAX parser).
+ * @author brianf
+ *
+ */
+public class ClasspathXMLResourceSelectionDialog extends ClasspathResourceSelectionDialog {
+
+    public ClasspathXMLResourceSelectionDialog(Shell parentShell, IContainer container, Set<String> fileExtensions,
+			String title) {
+		super(parentShell, container, fileExtensions, title);
+	}
+
+    @Override
+    protected ItemsFilter createFilter() {
+        return new XMLClasspathResourceFilter();
+    }
+
+    class XMLClasspathResourceFilter extends ClasspathResourceFilter {
+
+        @Override
+        public boolean matchItem(Object item) {
+        	boolean matches = super.matchItem(item);
+        	XmlMatchingStrategy strategy = new XmlMatchingStrategy();
+        	boolean isXml = false;
+        	if (item instanceof IFile) {
+        		isXml = strategy.matches((IFile) item);
+        	}
+        	return matches && isXml;
+        }
+
+        @Override
+        public boolean equalsFilter(ItemsFilter filter) {
+            return filter instanceof XMLClasspathResourceFilter && super.equalsFilter(filter);
+        }
+    }
+	
+    /**
+     * Matcher to see if the file parses as XML. 
+     * @author brianf
+     *
+     */
+    class XmlMatchingStrategy extends XmlMatchingStrategySupport {
+
+		@Override
+		protected FindNamespaceHandlerSupport createNamespaceFinder() {
+			return new FindNamespaceHandlerSupport(new HashSet<String>());
+		}
+    	
+		/* (non-Javadoc)
+		 * @see org.fusesource.ide.commons.contenttype.XmlMatchingStrategySupport#matches(org.eclipse.core.resources.IFile)
+		 */
+		public boolean matches(IFile ifile) {
+			try {
+				File file = IFiles.toFile(ifile);
+				if (file != null) {
+					// lets parse the XML and look for the namespaces 
+					FindNamespaceHandlerSupport handler = createNamespaceFinder();
+					boolean canParse = handler.parseContents(new InputSource(new FileInputStream(file)));
+					return canParse;
+				}
+			} catch (Exception e) {
+				// ignore anything that's not XML
+			}
+			return false;
+		}
+    }
+}

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/wizards/XMLPage.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/wizards/XMLPage.java
@@ -17,6 +17,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import javax.xml.namespace.QName;
@@ -64,6 +65,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.jboss.tools.fuse.transformation.editor.Activator;
 import org.jboss.tools.fuse.transformation.editor.internal.util.ClasspathResourceSelectionDialog;
+import org.jboss.tools.fuse.transformation.editor.internal.util.ClasspathXMLResourceSelectionDialog;
 import org.jboss.tools.fuse.transformation.model.xml.XmlModelGenerator;
 
 /**
@@ -317,13 +319,17 @@ public class XMLPage extends XformWizardPage implements TransformationTypePage {
             }
         }
         ClasspathResourceSelectionDialog dialog = null;
+        HashSet<String> extensions = new HashSet<String>();
+        extensions.add("xml");
+        extensions.add("xsd");
+        extensions.add("wsdl");
         if (javaProject == null) {
-            dialog = new ClasspathResourceSelectionDialog(shell, ResourcesPlugin.getWorkspace().getRoot(), extension);
+            dialog = new ClasspathXMLResourceSelectionDialog(shell, ResourcesPlugin.getWorkspace().getRoot(), extensions, "Select XML file in Project Classpath");
         } else {
-            dialog = new ClasspathResourceSelectionDialog(shell, javaProject.getProject(), extension);
+            dialog = new ClasspathXMLResourceSelectionDialog(shell, javaProject.getProject(), extensions, "Select XML file in Project Classpath");
         }
         dialog.setTitle("Select " + extension.toUpperCase() + " From Project");
-        dialog.setInitialPattern("*." + extension); //$NON-NLS-1$
+        dialog.setInitialPattern("*.*");//" + extension); //$NON-NLS-1$
         dialog.open();
         Object[] result = dialog.getResult();
         if (result == null || result.length == 0 || !(result[0] instanceof IResource)) {


### PR DESCRIPTION
Also fixed an issue introduced by the jar refactoring in FUSETOOLS-1421 where we really need access to jaxb-impl as well as xjc. Otherwise we can't generate models successfully. 