### PR TITLE
Launch Integration tests in a workspace which path contains special

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -337,6 +337,7 @@
 						<include>**/*IT.class</include>
 					</includes>
 					<argLine>${tycho.testArgLine} -XX:+HeapDumpOnOutOfMemoryError</argLine>
+					<osgiDataDirectory>${project.basedir}/target/work sp@cé</osgiDataDirectory>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
characters

following https://issues.jboss.org/browse/FUSETOOLS-1647 I think that it would be a good idea