### PR TITLE
Select Diagram node when double-clicking on Marker in problem view (see

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/BasicNodeValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/BasicNodeValidator.java
@@ -292,10 +292,9 @@ public class BasicNodeValidator implements ValidationSupport {
 		if (lineNumber == -1) {
 			marker.setAttribute(IMarker.LOCATION, "/" + getCamelPath(cme));
 		} else {
-			// register location to be able to redirect inside the diagram?
-			// marker.setAttribute(IMarker.FUSE_LOCATION, "/" +
-			// getCamelPath(cme));
+			marker.setAttribute(IFuseMarker.PATH, "/" + getCamelPath(cme));
 		}
+		marker.setAttribute(IFuseMarker.CAMEL_ID, cme.getId());
 	}
 
 	public List<Integer> findLineNumbers(String word, File text) {

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/IFuseMarker.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/IFuseMarker.java
@@ -1,0 +1,22 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.camel.validation.diagram;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public interface IFuseMarker {
+
+	public static final String PATH = "IFuseMarker_PATH";
+	public static final String CAMEL_ID = "IFuseMarker_CAMEL_ID";
+
+}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelEditor.java
@@ -49,6 +49,7 @@ import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.editors.text.TextEditor;
+import org.eclipse.ui.ide.IGotoMarker;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.part.MultiPageEditorPart;
 import org.eclipse.ui.texteditor.IDocumentProvider;
@@ -706,6 +707,8 @@ public class CamelEditor extends MultiPageEditorPart implements IResourceChangeL
 					return answer;
 				}
 			}
+		} else if (adapter == IGotoMarker.class) {
+			return new GoToMarkerForCamelEditor(this);
 		}
 		return super.getAdapter(adapter);
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/GoToMarkerForCamelEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/GoToMarkerForCamelEditor.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.camel.editor;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.ide.IGotoMarker;
+import org.eclipse.ui.texteditor.MarkerUtilities;
+import org.eclipse.wst.sse.ui.StructuredTextEditor;
+import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
+import org.fusesource.ide.camel.model.service.core.model.CamelFile;
+import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public class GoToMarkerForCamelEditor implements IGotoMarker {
+
+	private CamelEditor camelEditor;
+
+	/**
+	 * @param camelEditor
+	 */
+	public GoToMarkerForCamelEditor(CamelEditor camelEditor) {
+		this.camelEditor = camelEditor;
+	}
+
+	/**
+	 * Go to the better fitted editor: Camel Route or if can't find the element
+	 * in them, go to source editor
+	 */
+	@Override
+	public void gotoMarker(IMarker marker) {
+		try {
+			String id = (String) marker.getAttribute(IFuseMarker.CAMEL_ID);
+			if (id != null) {
+				final CamelDesignEditor designEditor = camelEditor.getDesignEditor();
+				CamelFile camelFile = designEditor.getModel();
+				CamelModelElement camelModelElement = camelFile.findNode(id);
+				if (camelModelElement != null) {
+					camelEditor.setActiveEditor(designEditor);
+					designEditor.setSelectedNode(camelModelElement);
+					// TODO: go to the exact Property place
+					return;
+				}
+			}
+		} catch (CoreException e) {
+			CamelEditorUIActivator.pluginLog().logError(e);
+		}
+
+
+
+		// Source editor
+		int lineNumber = MarkerUtilities.getLineNumber(marker);
+		if (lineNumber != -1) {
+			final StructuredTextEditor sourceEditor = camelEditor.getSourceEditor();
+			camelEditor.setActiveEditor(sourceEditor);
+			final IGotoMarker sourceEditorGoToMarker = (IGotoMarker) sourceEditor.getAdapter(IGotoMarker.class);
+			if (sourceEditorGoToMarker != null) {
+				sourceEditorGoToMarker.gotoMarker(marker);
+			}
+		}
+	}
+
+}

--- a/editor/tests/org.fusesource.ide.camel.editor.tests/src-test/java/org/fusesource/ide/camel/editor/GoToMarkerForCamelEditorTest.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests/src-test/java/org/fusesource/ide/camel/editor/GoToMarkerForCamelEditorTest.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/
+package org.fusesource.ide.camel.editor;
+
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.ui.ide.IGotoMarker;
+import org.eclipse.wst.sse.ui.StructuredTextEditor;
+import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelEndpoint;
+import org.fusesource.ide.camel.model.service.core.model.CamelFile;
+import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
+import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.w3c.dom.Node;
+
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class GoToMarkerForCamelEditorTest {
+
+	@Mock
+	private CamelEditor camelEditor;
+	@Mock
+	private CamelDesignEditor designEditor;
+	@Mock
+	private CamelGlobalConfigEditor configEditor;
+	@Mock
+	private StructuredTextEditor sourceEditor;
+	@Mock
+	private IGotoMarker sourceGotoMarker;
+	@Mock
+	private IMarker marker;
+	@Mock
+	private IResource resource;
+	@Mock
+	private Node xmlNode;
+
+	private GoToMarkerForCamelEditor goToMarkerForCamelEditor;
+
+
+	@Before
+	public void setup() throws CoreException {
+		goToMarkerForCamelEditor = new GoToMarkerForCamelEditor(camelEditor);
+		doReturn(sourceEditor).when(camelEditor).getSourceEditor();
+		doReturn(sourceGotoMarker).when(sourceEditor).getAdapter(IGotoMarker.class);
+		doReturn(designEditor).when(camelEditor).getDesignEditor();
+		doReturn(configEditor).when(camelEditor).getGlobalConfigEditor();
+		doReturn(true).when(marker).exists();
+		doReturn(10).when(marker).getAttribute(IMarker.LINE_NUMBER);
+	}
+
+	@Test
+	public void testGotoMarkerSource() throws Exception {
+		goToMarkerForCamelEditor.gotoMarker(marker);
+		verify(sourceEditor).getAdapter(IGotoMarker.class);
+		verify(sourceGotoMarker).gotoMarker(marker);
+		verify(camelEditor).setActiveEditor(sourceEditor);
+	}
+
+	@Test
+	public void testGotoMarkerDesignEditor() throws Exception {
+		doReturn("nodeId").when(marker).getAttribute(IFuseMarker.CAMEL_ID);
+
+		CamelFile camelFile = new CamelFile(resource);
+		CamelRouteElement route = new CamelRouteElement(new CamelContextElement(camelFile, null), null);
+		camelFile.addChildElement(route);
+		final CamelEndpoint endPoint = new CamelEndpoint("imap:host:port");
+		endPoint.setId("nodeId");
+		route.addChildElement(endPoint);
+		endPoint.setParent(route);
+		doReturn(camelFile).when(designEditor).getModel();
+
+		goToMarkerForCamelEditor.gotoMarker(marker);
+
+		verify(camelEditor).setActiveEditor(designEditor);
+		// Ensure Source Editor is no called
+		verify(sourceEditor, Mockito.never()).getAdapter(IGotoMarker.class);
+		verify(sourceGotoMarker, Mockito.never()).gotoMarker(marker);
+	}
+
+	@Test
+	public void testGotoMarkerDesignEditorFallBackSource() throws Exception {
+		doReturn("nodeId").when(marker).getAttribute(IFuseMarker.CAMEL_ID);
+
+		CamelFile camelFile = new CamelFile(resource);
+		CamelRouteElement route = new CamelRouteElement(new CamelContextElement(camelFile, null), null);
+		camelFile.addChildElement(route);
+		final CamelEndpoint endPoint = new CamelEndpoint("imap:host:port");
+		endPoint.setId("nodeIdDifferent");
+		route.addChildElement(endPoint);
+		endPoint.setParent(route);
+		doReturn(camelFile).when(designEditor).getModel();
+
+		goToMarkerForCamelEditor.gotoMarker(marker);
+		verify(sourceEditor).getAdapter(IGotoMarker.class);
+		verify(sourceGotoMarker).gotoMarker(marker);
+		verify(camelEditor).setActiveEditor(sourceEditor);
+	}
+
+}


### PR DESCRIPTION
FUSETOOLS-1656)

It redirects to Source editor when there is a line number provided and
no corresponding element found.