### PR TITLE
Provide Validation decorator in project explorer view (see

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/BasicNodeValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/BasicNodeValidator.java
@@ -33,7 +33,6 @@ import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
-import org.fusesource.ide.camel.validation.CamelValidationActivator;
 import org.fusesource.ide.camel.validation.ValidationResult;
 import org.fusesource.ide.camel.validation.ValidationSupport;
 import org.fusesource.ide.camel.validation.model.NumberValidator;
@@ -46,7 +45,6 @@ import org.fusesource.ide.foundation.core.util.Strings;
  */
 public class BasicNodeValidator implements ValidationSupport {
 
-	public static final String MARKER_TYPE = CamelValidationActivator.PLUGIN_ID + ".JBossFuseToolingValidationProblem";
 	private static Map<IMarker, CamelModelElement> markers = new HashMap<>();
 
 	/*
@@ -104,7 +102,7 @@ public class BasicNodeValidator implements ValidationSupport {
 			if (camelFile != null) {
 				final IResource resource = camelFile.getResource();
 				if (resource != null) {
-					for (IMarker marker : resource.findMarkers(MARKER_TYPE, true, IResource.DEPTH_INFINITE)) {
+					for (IMarker marker : resource.findMarkers(IFuseMarker.MARKER_TYPE, true, IResource.DEPTH_INFINITE)) {
 						final CamelModelElement cmeWithMarker = markers.get(marker);
 						if (camelModelElement.equals(cmeWithMarker)
 								// we are lucky still the same model in memory
@@ -273,7 +271,7 @@ public class BasicNodeValidator implements ValidationSupport {
 
 	private void createMarker(IResource resource, CamelModelElement cme, final String message, final int severity) {
 		try {
-			IMarker marker = resource.createMarker(MARKER_TYPE);
+			IMarker marker = resource.createMarker(IFuseMarker.MARKER_TYPE);
 			marker.setAttribute(IMarker.SEVERITY, severity);
 			marker.setAttribute(IMarker.MESSAGE, message);
 			marker.setAttribute(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/IFuseMarker.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/IFuseMarker.java
@@ -10,6 +10,8 @@
  ******************************************************************************/ 
 package org.fusesource.ide.camel.validation.diagram;
 
+import org.fusesource.ide.camel.validation.CamelValidationActivator;
+
 /**
  * @author Aurelien Pupier
  *
@@ -18,5 +20,6 @@ public interface IFuseMarker {
 
 	public static final String PATH = "IFuseMarker_PATH";
 	public static final String CAMEL_ID = "IFuseMarker_CAMEL_ID";
+	String MARKER_TYPE = CamelValidationActivator.PLUGIN_ID + ".JBossFuseToolingValidationProblem";
 
 }

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/xml/XMLCamelRoutesValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/xml/XMLCamelRoutesValidator.java
@@ -21,6 +21,7 @@ import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 import org.fusesource.ide.camel.validation.diagram.BasicNodeValidator;
+import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
 
 public class XMLCamelRoutesValidator extends AbstractValidator {
 
@@ -36,7 +37,7 @@ public class XMLCamelRoutesValidator extends AbstractValidator {
 	public ValidationResult validate(ValidationEvent event, ValidationState state, IProgressMonitor monitor) {
 		IResource resource = event.getResource();
 		try {
-			resource.deleteMarkers(BasicNodeValidator.MARKER_TYPE, true, IResource.DEPTH_INFINITE);
+			resource.deleteMarkers(IFuseMarker.MARKER_TYPE, true, IResource.DEPTH_INFINITE);
 		} catch (CoreException e) {
 			e.printStackTrace();
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.camel.editor/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-Vendor: %Bundle-Vendor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: org.fusesource.ide.camel.editor,
  org.fusesource.ide.camel.editor.features.create.ext,
+ org.fusesource.ide.camel.editor.navigator,
  org.fusesource.ide.camel.editor.properties;x-friends:="org.fusesource.ide.camel.editor.tests",
  org.fusesource.ide.camel.editor.provider.ext,
  org.fusesource.ide.camel.editor.utils

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
@@ -79,7 +79,7 @@ import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.ICamelModelListener;
-import org.fusesource.ide.camel.validation.diagram.BasicNodeValidator;
+import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
 import org.fusesource.ide.foundation.core.util.Objects;
 import org.fusesource.ide.foundation.ui.io.CamelXMLEditorInput;
 import org.fusesource.ide.foundation.ui.util.Selections;
@@ -206,7 +206,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 			// clear Old Validation Markers,
 			// they will be recalculated when opening the diagram
 			try {
-				asFileEditorInput(input).getFile().deleteMarkers(BasicNodeValidator.MARKER_TYPE, true, IResource.DEPTH_INFINITE);
+				asFileEditorInput(input).getFile().deleteMarkers(IFuseMarker.MARKER_TYPE, true, IResource.DEPTH_INFINITE);
 			} catch (CoreException e) {
 				CamelEditorUIActivator.pluginLog().logError(e);
 			}

--- a/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
@@ -18,7 +18,10 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.106.0",
  org.eclipse.m2e.maven.runtime;bundle-version="1.5.0",
  org.fusesource.ide.branding;bundle-version="8.0.0",
  org.fusesource.ide.foundation.core;bundle-version="8.0.0",
- org.fusesource.ide.foundation.ui;bundle-version="8.0.0"
+ org.fusesource.ide.foundation.ui;bundle-version="8.0.0",
+ org.fusesource.ide.camel.model.service.core;bundle-version="8.0.0",
+ org.fusesource.ide.camel.validation;bundle-version="8.0.0",
+ org.fusesource.ide.camel.editor
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.project.Activator
 Export-Package: org.fusesource.ide.project,

--- a/editor/plugins/org.fusesource.ide.project/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.project/plugin.xml
@@ -220,4 +220,28 @@
           id="org.fusesource.ide.project.image"
           typeIds="fuse.camel"/>
  </extension>
+ <extension
+       point="org.eclipse.ui.decorators">
+    <decorator
+          class="org.fusesource.ide.project.decorator.CamelRouteProblemDecorator"
+          id="org.fusesource.ide.project.decorator.problem.route"
+          label="Camel Route Problem Decorator"
+          lightweight="true"
+          location="BOTTOM_LEFT"
+          state="true">
+       <enablement>
+          <or>
+             <objectClass
+                   name="org.fusesource.ide.project.providers.CamelVirtualFolder">
+             </objectClass>
+             <objectClass
+                   name="org.fusesource.ide.camel.model.service.core.model.CamelRouteElement">
+             </objectClass>
+             <objectClass
+                   name="org.fusesource.ide.camel.editor.navigator.CamelCtxNavRouteNode">
+             </objectClass>
+          </or>
+       </enablement>
+    </decorator>
+ </extension>
 </plugin>

--- a/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/decorator/CamelRouteProblemDecorator.java
+++ b/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/decorator/CamelRouteProblemDecorator.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.project.decorator;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.viewers.IDecoration;
+import org.eclipse.jface.viewers.ILabelProviderListener;
+import org.eclipse.jface.viewers.ILightweightLabelDecorator;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.PlatformUI;
+import org.fusesource.ide.camel.editor.navigator.CamelCtxNavRouteNode;
+import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
+import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
+import org.fusesource.ide.project.Activator;
+import org.fusesource.ide.project.providers.CamelVirtualFolder;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public class CamelRouteProblemDecorator implements ILightweightLabelDecorator {
+
+	@Override
+	public void addListener(ILabelProviderListener listener) {
+	}
+
+	@Override
+	public void dispose() {
+	}
+
+	@Override
+	public boolean isLabelProperty(Object element, String property) {
+		return false;
+	}
+
+	@Override
+	public void removeListener(ILabelProviderListener listener) {
+	}
+
+	@Override
+	public void decorate(Object element, IDecoration decoration) {
+		if (element instanceof CamelVirtualFolder) {
+			decorationForCamelVirtualFolder(element, decoration);
+		} else if (element instanceof CamelRouteElement) {
+			decorationForCamelRoute((CamelRouteElement) element, decoration);
+		} else if (element instanceof CamelCtxNavRouteNode) {
+			decorationForCamelRoute(((CamelCtxNavRouteNode) element).getCamelRoute(), decoration);
+		}
+	}
+
+	/**
+	 * @param element
+	 * @param decoration
+	 */
+	private void decorationForCamelVirtualFolder(Object element, IDecoration decoration) {
+		for (IResource resource : ((CamelVirtualFolder) element).getCamelFiles()) {
+			try {
+				int maxProblemSeverity = resource.findMaxProblemSeverity(IMarker.PROBLEM, true, IResource.DEPTH_ZERO);
+				decoration.addOverlay(getOverlay(maxProblemSeverity));
+			} catch (CoreException e) {
+				Activator.getLogger().error(e);
+			}
+		}
+	}
+
+	/**
+	 * @param camelRoute
+	 * @param decoration
+	 */
+	private void decorationForCamelRoute(CamelRouteElement camelRoute, IDecoration decoration) {
+		IResource resource = camelRoute.getCamelFile().getResource();
+		try {
+			IMarker[] markers = resource.findMarkers(IFuseMarker.MARKER_TYPE, true, IResource.DEPTH_INFINITE);
+			for (IMarker marker : markers) {
+				String id = (String) marker.getAttribute(IFuseMarker.CAMEL_ID);
+				if (id != null) {
+					if (isInsideRoute(camelRoute, id)) {
+						decoration.addOverlay(getOverlay((int) marker.getAttribute(IMarker.SEVERITY)));
+						return;
+					}
+				}
+			}
+		} catch (CoreException e) {
+			Activator.getLogger().error(e);
+		}
+	}
+
+	/**
+	 * @param camelRoute
+	 * @param id
+	 * @return if the Camel Element with 'id' is inside the 'camelRoute'
+	 */
+	private boolean isInsideRoute(CamelRouteElement camelRoute, String id) {
+		CamelModelElement current = ((CamelRouteElement) camelRoute).getCamelFile().findNode(id);
+		while (current != null) {
+			if (camelRoute.equals(current)) {
+				return true;
+			} else {
+				current = current.getParent();
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * @return The overlay image corresponding to the Marker severity
+	 */
+	private ImageDescriptor getOverlay(int problemSeverity) {
+		if (problemSeverity == IMarker.SEVERITY_ERROR) {
+			return PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_DEC_FIELD_ERROR);
+		} else if (problemSeverity == IMarker.SEVERITY_WARNING) {
+			return PlatformUI.getWorkbench().getSharedImages().getImageDescriptor(ISharedImages.IMG_DEC_FIELD_WARNING);
+		} else {
+			return null;
+		}
+	}
+
+}

--- a/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/providers/CamelFilesContentProvider.java
+++ b/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/providers/CamelFilesContentProvider.java
@@ -42,9 +42,7 @@ public class CamelFilesContentProvider implements ITreeContentProvider {
 				cache.put(project, cvf);
 			}
 
-			CamelVirtualFolder[] resVal = new CamelVirtualFolder[1];
-			resVal[0] = cvf;
-			return resVal;
+			return new CamelVirtualFolder[] { cvf };
 		} else if (parentElement instanceof CamelVirtualFolder) {
 			CamelVirtualFolder cvf = (CamelVirtualFolder) parentElement;
 			return cvf.getCamelFiles().toArray(
@@ -55,6 +53,9 @@ public class CamelFilesContentProvider implements ITreeContentProvider {
 
 	@Override
 	public Object getParent(Object element) {
+		if (element instanceof CamelVirtualFolder) {
+			return ((CamelVirtualFolder) element).getProject();
+		}
 		return null;
 	}
 


### PR DESCRIPTION
FUSETOOLS-1659)

I detected some refresh issue of the markers in Problem explorer view.
Some are related to what I have done and some others were already there (the ones on the xml file)
I can't figure out what is happening. I think it is worthy enough to provide it as is anyway. The user just need to call Refresh (F5) on the project when it occurs.
