### PR TITLE
FUSETOOLS-1427 - Refresh Camel Nodes in JMX View on start/stop tracing

### DIFF
--- a/core/plugins/org.fusesource.ide.foundation.ui/META-INF/MANIFEST.MF
+++ b/core/plugins/org.fusesource.ide.foundation.ui/META-INF/MANIFEST.MF
@@ -25,7 +25,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.11.0",
  org.jboss.tools.foundation.core;bundle-version="1.2.0",
  org.jboss.tools.foundation.ui;bundle-version="1.2.0",
  org.fusesource.ide.foundation.core;bundle-version="8.0.0",
- org.fusesource.ide.preferences;bundle-version="8.0.0"
+ org.fusesource.ide.preferences;bundle-version="8.0.0",
+ org.jboss.tools.jmx.jvmmonitor.ui
 Bundle-Activator: org.fusesource.ide.foundation.ui.internal.FoundationUIActivator
 Bundle-ActivationPolicy: lazy
 Bundle-ClassPath: .

--- a/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/tree/NodeSupport.java
+++ b/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/tree/NodeSupport.java
@@ -24,9 +24,7 @@ import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 import org.fusesource.ide.foundation.ui.internal.FoundationUIActivator;
 import org.fusesource.ide.foundation.ui.propsrc.BeanPropertySource;
 import org.fusesource.ide.foundation.ui.util.Nodes;
-import org.fusesource.ide.foundation.ui.util.UIHelper;
 import org.jboss.tools.jmx.core.tree.Node;
-import org.jboss.tools.jmx.ui.internal.actions.RefreshAction;
 
 
 public abstract class NodeSupport extends Node implements IAdaptable, RefreshableUI, HasRefreshableUI, IPropertySourceProvider, ITabbedPropertySheetPageContributor {
@@ -156,13 +154,7 @@ public abstract class NodeSupport extends Node implements IAdaptable, Refreshabl
 	 */
 	@Override
 	public void fireRefresh() {
-		Display.getDefault().syncExec(new Runnable() {
-			@Override
-			public void run() {
-				RefreshAction ra = new RefreshAction(UIHelper.ID_JMX_EXPORER);
-				ra.run();
-			}
-		});
+		Display.getDefault().syncExec(new RefreshNodeRunnable(this));
 	}
 	
 	/* (non-Javadoc)

--- a/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/tree/RefreshNodeRunnable.java
+++ b/core/plugins/org.fusesource.ide.foundation.ui/src/org/fusesource/ide/foundation/ui/tree/RefreshNodeRunnable.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.foundation.ui.tree;
+
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.navigator.CommonViewer;
+import org.jboss.tools.jmx.ui.internal.views.navigator.JMXNavigator;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public final class RefreshNodeRunnable implements Runnable {
+
+	private final NodeSupport nodeSupport;
+
+	/**
+	 * @param nodeSupportToRefresh
+	 */
+	public RefreshNodeRunnable(NodeSupport nodeSupportToRefresh) {
+		this.nodeSupport = nodeSupportToRefresh;
+	}
+
+	@Override
+	public void run() {
+		JMXNavigator jmxView = getJMXNavigatorView();
+		if (jmxView != null) {
+			CommonViewer commonViewer = (CommonViewer) jmxView.getAdapter(CommonViewer.class);
+			commonViewer.update(this.nodeSupport, null);
+		}
+	}
+
+	private JMXNavigator getJMXNavigatorView() {
+		final IWorkbenchWindow activeWorkbenchWindow = PlatformUI.getWorkbench().getActiveWorkbenchWindow();
+		if (activeWorkbenchWindow != null) {
+			final IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
+			if (activePage != null) {
+				return (JMXNavigator) activePage.findView(JMXNavigator.VIEW_ID);
+			}
+		}
+		return null;
+	}
+}

--- a/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/CamelContextNode.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/CamelContextNode.java
@@ -26,6 +26,7 @@ import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.Separator;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PartInitException;
@@ -43,6 +44,7 @@ import org.fusesource.ide.foundation.core.util.IOUtils;
 import org.fusesource.ide.foundation.core.util.Objects;
 import org.fusesource.ide.foundation.ui.io.CamelContextNodeEditorInput;
 import org.fusesource.ide.foundation.ui.tree.NodeSupport;
+import org.fusesource.ide.foundation.ui.tree.RefreshNodeRunnable;
 import org.fusesource.ide.foundation.ui.tree.Refreshable;
 import org.fusesource.ide.foundation.ui.util.ContextMenuProvider;
 import org.fusesource.ide.foundation.ui.util.Nodes;
@@ -109,6 +111,7 @@ public class CamelContextNode 	extends NodeSupport
 	@Override
 	public void refresh() {
 		Nodes.refreshParent(this);
+		Display.getDefault().syncExec(new RefreshNodeRunnable(this));
 	}
 
 	public CamelContextsNode getCamelContextsNode() {


### PR DESCRIPTION
decorator is now correctly refreshed when using start/stop tracing on Context node AND on Route node