### PR TITLE
FUSETOOLS-1643 - When Nothing is selected on the diagram, hide the

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
@@ -36,7 +36,7 @@ import org.w3c.dom.NodeList;
 /**
  * @author lhein
  */
-public class CamelModelElement {
+public abstract class AbstractCamelModelElement {
 
 	protected static final String ID_ATTRIBUTE = "id";
 	protected static final String DATA_FORMATS_NODE_NAME = "dataFormats";
@@ -45,16 +45,16 @@ public class CamelModelElement {
 	protected static final String CAMEL_CONTEXT_NODE_NAME = "camelContext";
 	
 	// children is a list of objects which are no route outputs
-	private List<CamelModelElement> childElements = new ArrayList<CamelModelElement>();
+	private List<AbstractCamelModelElement> childElements = new ArrayList<AbstractCamelModelElement>();
 
 	// input is the element which comes before this one
-	private CamelModelElement inputElement;
+	private AbstractCamelModelElement inputElement;
 
 	// output is the route output of this element
-	private CamelModelElement outputElement;
+	private AbstractCamelModelElement outputElement;
 
 	// the parent node
-	private CamelModelElement parent;
+	private AbstractCamelModelElement parent;
 
 	// the catalog element which represents this object
 	private Node xmlNode;
@@ -82,7 +82,7 @@ public class CamelModelElement {
 	 * @param underlyingNode
 	 *            the camel xml node
 	 */
-	public CamelModelElement(CamelModelElement parent, Node underlyingNode) {
+	protected AbstractCamelModelElement(AbstractCamelModelElement parent, Node underlyingNode) {
 		this.xmlNode = underlyingNode;
 		this.parent = parent;
 
@@ -133,14 +133,14 @@ public class CamelModelElement {
 	 * @param uri
 	 * @return
 	 */
-	public CamelModelElement findEndpoint(String uri) {
+	public AbstractCamelModelElement findEndpoint(String uri) {
 		if (getChildElements().isEmpty()) {
 			if (getParameter("uri") != null && ((String)getParameter("uri")).equals(uri)) {
 				return this;
 			}
 		} else {
-			for (CamelModelElement cme : getChildElements()) {
-				CamelModelElement e = cme.findEndpoint(uri);
+			for (AbstractCamelModelElement cme : getChildElements()) {
+				AbstractCamelModelElement e = cme.findEndpoint(uri);
 				if (e != null) return e;
 			}	
 		}		
@@ -212,7 +212,7 @@ public class CamelModelElement {
 	/**
 	 * @return the parent
 	 */
-	public CamelModelElement getParent() {
+	public AbstractCamelModelElement getParent() {
 		return this.parent;
 	}
 
@@ -220,7 +220,7 @@ public class CamelModelElement {
 	 * @param parent
 	 *            the parent to set
 	 */
-	public void setParent(CamelModelElement parent) {
+	public void setParent(AbstractCamelModelElement parent) {
 		this.parent = parent;
 	}
 
@@ -345,9 +345,9 @@ public class CamelModelElement {
 		if( propertyToCheck != null ) {
 			Object propVal = getParameter(propertyToCheck);
 			if (propVal != null) {
-				if( propVal instanceof CamelModelElement) {
+				if( propVal instanceof AbstractCamelModelElement) {
 					// seems to be an expression
-					String expression = ((CamelModelElement)propVal).getParameter("expression") != null ? (String)((CamelModelElement)propVal).getParameter("expression") : null;
+					String expression = ((AbstractCamelModelElement)propVal).getParameter("expression") != null ? (String)((AbstractCamelModelElement)propVal).getParameter("expression") : null;
 					if (expression != null)	return result + expression;			
 				} else {
 					return result + propVal.toString();
@@ -442,7 +442,7 @@ public class CamelModelElement {
 	/**
 	 * @return the inputElement
 	 */
-	public CamelModelElement getInputElement() {
+	public AbstractCamelModelElement getInputElement() {
 		return this.inputElement;
 	}
 
@@ -454,7 +454,7 @@ public class CamelModelElement {
 	 * @param inputElement
 	 *            the inputElement to set
 	 */
-	public void setInputElement(CamelModelElement inputElement) {
+	public void setInputElement(AbstractCamelModelElement inputElement) {
 		this.inputElement = inputElement;
 		// now move the node directly after inputElement in DOM tree
 		if (inputElement != null) {
@@ -533,7 +533,7 @@ public class CamelModelElement {
 	/**
 	 * @return the outputElement
 	 */
-	public CamelModelElement getOutputElement() {
+	public AbstractCamelModelElement getOutputElement() {
 		return this.outputElement;
 	}
 
@@ -541,7 +541,7 @@ public class CamelModelElement {
 	 * @param outputElement
 	 *            the outputElement to set
 	 */
-	public void setOutputElement(CamelModelElement outputElement) {
+	public void setOutputElement(AbstractCamelModelElement outputElement) {
 		this.outputElement = outputElement;
 		if (isEndpointElement()) {
 			checkEndpointType();
@@ -551,7 +551,7 @@ public class CamelModelElement {
 	/**
 	 * @return the childElements
 	 */
-	public List<CamelModelElement> getChildElements() {
+	public List<AbstractCamelModelElement> getChildElements() {
 		return this.childElements;
 	}
 
@@ -559,7 +559,7 @@ public class CamelModelElement {
 	 * @param childElements
 	 *            the childElements to set
 	 */
-	public void setChildElements(List<CamelModelElement> childElements) {
+	public void setChildElements(List<AbstractCamelModelElement> childElements) {
 		this.childElements = childElements;
 	}
 
@@ -575,7 +575,7 @@ public class CamelModelElement {
 	 * 
 	 * @param element
 	 */
-	public void addChildElement(CamelModelElement element) {
+	public void addChildElement(AbstractCamelModelElement element) {
 		if (this.childElements.contains(element) == false) {
 			this.childElements.add(element);
 		}
@@ -586,7 +586,7 @@ public class CamelModelElement {
 	 * 
 	 * @param element
 	 */
-	public void removeChildElement(CamelModelElement element) {
+	public void removeChildElement(AbstractCamelModelElement element) {
 		if (childElements.contains(element)) {
 			childElements.remove(element);
 			boolean childFound = false;
@@ -628,8 +628,8 @@ public class CamelModelElement {
 	public void removeParameter(String name) {
 		if (this.parameters.containsKey(name)) {
 			Object removedItem = this.parameters.remove(name);
-			if (removedItem instanceof CamelModelElement) {
-				getXmlNode().removeChild(((CamelModelElement)removedItem).getXmlNode());
+			if (removedItem instanceof AbstractCamelModelElement) {
+				getXmlNode().removeChild(((AbstractCamelModelElement)removedItem).getXmlNode());
 			}
 			((Element) getXmlNode()).removeAttribute(name);
 		}
@@ -699,7 +699,7 @@ public class CamelModelElement {
 		// save param in internal map
 		this.parameters.put(name, value);
 		
-		if (value instanceof CamelModelElement && getParameter("ref") != null) {
+		if (value instanceof AbstractCamelModelElement && getParameter("ref") != null) {
 			removeParameter("ref");
 		} else if (name.equalsIgnoreCase("ref")) {
 			removePossibleDataFormatsInFavorToREF();
@@ -730,13 +730,13 @@ public class CamelModelElement {
 				e.setTextContent(null);
 			}
 		} else {
-			if (kind == null && value instanceof CamelModelElement == false) {
+			if (kind == null && value instanceof AbstractCamelModelElement == false) {
 				kind = "value";
 			}
-			if (kind == null && value instanceof CamelModelElement) {
+			if (kind == null && value instanceof AbstractCamelModelElement) {
 				// special case for nested expressions
 				Node oldChild = getFirstChild(e);
-				Node newChild = ((CamelModelElement) value).getXmlNode();
+				Node newChild = ((AbstractCamelModelElement) value).getXmlNode();
 				e.replaceChild(newChild, oldChild);
 			} else if (kind.equalsIgnoreCase("attribute")) {
 				String defaultValue = this.underlyingMetaModelObject != null
@@ -772,9 +772,9 @@ public class CamelModelElement {
 				}
 			} else if (kind.equalsIgnoreCase("element") && javaType.equals("org.apache.camel.model.DataFormatDefinition")) {
 				// expression element handling
-				CamelModelElement df = null;
-				if (value instanceof CamelModelElement) {
-					df = (CamelModelElement) value;
+				AbstractCamelModelElement df = null;
+				if (value instanceof AbstractCamelModelElement) {
+					df = (AbstractCamelModelElement) value;
 				}
 				Eip subEip = getEipByName(df.getNodeTypeId());
 				if (subEip != null) {
@@ -817,9 +817,9 @@ public class CamelModelElement {
 				}
 			} else if (kind.equalsIgnoreCase("expression")) {
 				// expression element handling
-				CamelModelElement exp = null;
-				if (value instanceof CamelModelElement) {
-					exp = (CamelModelElement) value;
+				AbstractCamelModelElement exp = null;
+				if (value instanceof AbstractCamelModelElement) {
+					exp = (AbstractCamelModelElement) value;
 				}
 				Eip subEip = getEipByName(exp.getNodeTypeId());
 				if (subEip != null) {
@@ -876,7 +876,7 @@ public class CamelModelElement {
 							break;
 						}
 					}
-					Node newChild = ((CamelModelElement) value).getXmlNode();
+					Node newChild = ((AbstractCamelModelElement) value).getXmlNode();
 					e.replaceChild(newChild, oldChild);
 				}
 			} else if (kind.equalsIgnoreCase("value")) {
@@ -948,7 +948,7 @@ public class CamelModelElement {
 		linkChildrenToAttributes();
 	}
 
-	public void ensureUniqueID(CamelModelElement elem) {
+	public void ensureUniqueID(AbstractCamelModelElement elem) {
 		// if this element is also a parent element parameter then we don't
 		// set ID values (example: parent = onException, element: exception)
 		if (elem.getParent().getParameter(elem.getTranslatedNodeName()) != null && 
@@ -963,7 +963,7 @@ public class CamelModelElement {
 				elem.setId(elem.getNewID());
 			}
 		}
-		for (CamelModelElement e : elem.getChildElements()) {
+		for (AbstractCamelModelElement e : elem.getChildElements()) {
 			e.ensureUniqueID(e);
 		}
 	}
@@ -1030,7 +1030,7 @@ public class CamelModelElement {
 					}
 				} else if (	param.getKind().equalsIgnoreCase("element") && 
 							param.getJavaType().equalsIgnoreCase("org.apache.camel.model.DataFormatDefinition")) {
-					CamelModelElement dfNode = null;
+					AbstractCamelModelElement dfNode = null;
 					String[] dfs = param.getOneOf().split(",");
 					ArrayList<String> dfList = new ArrayList<String>();
 					for (String df : dfs)
@@ -1039,14 +1039,14 @@ public class CamelModelElement {
 						Node subNode = getXmlNode().getChildNodes().item(i);
 						if (subNode.getNodeType() != Node.ELEMENT_NODE) continue;
 						if (subNode != null && dfList.contains(CamelUtils.getTranslatedNodeName(subNode))) {
-							dfNode = new CamelModelElement(this, subNode);
+							dfNode = new CamelBasicModelElement(this, subNode);
 							dfNode.initialize();
 							// expNode.setParent(this);
 							setParameter(param.getName(), dfNode);
 						}
 					}
 				} else if (param.getKind().equalsIgnoreCase("expression")) {
-					CamelModelElement expNode = null;
+					AbstractCamelModelElement expNode = null;
 					String[] langs = param.getOneOf().split(",");
 					ArrayList<String> langList = new ArrayList<String>();
 					for (String lang : langs)
@@ -1060,7 +1060,7 @@ public class CamelModelElement {
 							// this case is for expressions which are directly
 							// stored under the parent node
 							// for instance when.<expression>
-							expNode = new CamelModelElement(this, subNode);
+							expNode = new CamelBasicModelElement(this, subNode);
 							expNode.initialize();
 							// expNode.setParent(this);
 							setParameter(param.getName(), expNode);
@@ -1076,10 +1076,10 @@ public class CamelModelElement {
 								if (subExpNode.getNodeType() == Node.ELEMENT_NODE && subExpNode != null
 										&& langList.contains(CamelUtils.getTranslatedNodeName(subExpNode))) {
 									// found the sub -> create container element
-									CamelModelElement expContainer = new CamelModelElement(this, subNode);
+									AbstractCamelModelElement expContainer = new CamelBasicModelElement(this, subNode);
 									// expContainer.initialize();
 									// expContainer.setParent(this);
-									expNode = new CamelModelElement(expContainer, subExpNode);
+									expNode = new CamelBasicModelElement(expContainer, subExpNode);
 									expNode.initialize();
 									// expNode.setParent(this);
 									expContainer.setParameter("expression", expNode);
@@ -1181,13 +1181,13 @@ public class CamelModelElement {
 		boolean canHaveChildren = hasChildren(nodeName) || hasSpecialHandling(nodeName);
 		if (canHaveChildren) {
 			NodeList children = getXmlNode().getChildNodes();
-			CamelModelElement lastNode = null;
+			AbstractCamelModelElement lastNode = null;
 			for (int i = 0; i < children.getLength(); i++) {
 				Node tmp = children.item(i);
 				if (tmp.getNodeType() != Node.ELEMENT_NODE)
 					continue;
 				if (!isUsedAsAttribute(tmp)) {
-					CamelModelElement cme = new CamelModelElement(this, tmp);
+					AbstractCamelModelElement cme = new CamelBasicModelElement(this, tmp);
 					addChildElement(cme);
 					cme.initialize();
 					boolean createLink = lastNode != null && this.getNodeTypeId().equals("choice") == false;
@@ -1257,7 +1257,7 @@ public class CamelModelElement {
 			return;
 		for (Parameter p : getUnderlyingMetaModelObject().getParameters()) {
 			if (p.getKind().equalsIgnoreCase("expression") || p.getKind().equalsIgnoreCase("element")) {
-				for (CamelModelElement child : getChildElements()) {
+				for (AbstractCamelModelElement child : getChildElements()) {
 					if (child.getNodeTypeId().equalsIgnoreCase(p.getName()) && p.getType().equalsIgnoreCase("object")) {
 						// so we have a child of type element or expression
 						// which should be handled as an attribute
@@ -1309,7 +1309,7 @@ public class CamelModelElement {
 				if (u.startsWith("ref:")) {
 					// if its a ref we lookup what is the reference scheme
 					String refId = u.substring(u.indexOf(":") + 1);
-					CamelModelElement endpointRef = getCamelContext().getEndpointDefinitions().get(refId);
+					AbstractCamelModelElement endpointRef = getCamelContext().getEndpointDefinitions().get(refId);
 					if (endpointRef != null) {
 						String refUri = (String) endpointRef.getParameter("uri");
 						if (refUri != null) {
@@ -1403,7 +1403,7 @@ public class CamelModelElement {
 	 */
 	public CamelFile getCamelFile() {
 		if (this.cf == null) {
-			CamelModelElement tmp = this;
+			AbstractCamelModelElement tmp = this;
 			while (tmp.getParent() != null && tmp.getParent() instanceof CamelFile == false) {
 				tmp = tmp.getParent();
 			}
@@ -1421,7 +1421,7 @@ public class CamelModelElement {
 	 */
 	public CamelContextElement getCamelContext() {
 		if (this.context == null) {
-			CamelModelElement tmp = this;
+			AbstractCamelModelElement tmp = this;
 			while (tmp.getParent() != null && tmp.getParent() instanceof CamelContextElement == false) {
 				tmp = tmp.getParent();
 			}
@@ -1484,7 +1484,7 @@ public class CamelModelElement {
 	 * @param nodeId
 	 * @return the node or null
 	 */
-	public CamelModelElement findNode(String nodeId) {
+	public AbstractCamelModelElement findNode(String nodeId) {
 		if (getId() != null && getId().equals(nodeId)) {
 			return this;
 		}
@@ -1504,8 +1504,8 @@ public class CamelModelElement {
 		}
 		
 		if (getChildElements() != null) {
-			for (CamelModelElement e : getChildElements()) {
-				CamelModelElement cme = e.findNode(nodeId);
+			for (AbstractCamelModelElement e : getChildElements()) {
+				AbstractCamelModelElement cme = e.findNode(nodeId);
 				if (cme != null)
 					return cme;
 			}
@@ -1514,29 +1514,15 @@ public class CamelModelElement {
 		return null;
 	}
 	
-	public ArrayList<CamelModelElement> findAllNodesWithId(String nodeId) {
-		ArrayList<CamelModelElement> result = new ArrayList<CamelModelElement>();
+	public List<AbstractCamelModelElement> findAllNodesWithId(String nodeId) {
+		List<AbstractCamelModelElement> result = new ArrayList<AbstractCamelModelElement>();
 		
 		if (getId() != null && getId().equals(nodeId)) {
 			result.add(this);
 		}
-
-		if (this instanceof CamelContextElement) {
-			CamelContextElement ctx = (CamelContextElement)this;
-			if (ctx.getDataformats().isEmpty() == false) {
-				if (ctx.getDataformats().containsKey(nodeId)) {
-					result.add(ctx.getDataformats().get(nodeId));
-				}
-			}
-			if (ctx.getEndpointDefinitions().isEmpty() == false) {
-				if (ctx.getEndpointDefinitions().containsKey(nodeId)) {
-					result.add(ctx.getEndpointDefinitions().get(nodeId));
-				}
-			}
-		}
 		
 		if (getChildElements() != null) {
-			for (CamelModelElement e : getChildElements()) {
+			for (AbstractCamelModelElement e : getChildElements()) {
 				result.addAll(e.findAllNodesWithId(nodeId));
 			}
 		}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelBasicModelElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelBasicModelElement.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.camel.model.service.core.model;
+
+import org.w3c.dom.Node;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public class CamelBasicModelElement extends AbstractCamelModelElement implements IFuseDetailsPropertyContributor {
+
+	/**
+	 * @param parent
+	 * @param underlyingNode
+	 */
+	public CamelBasicModelElement(AbstractCamelModelElement parent, Node underlyingNode) {
+		super(parent, underlyingNode);
+	}
+
+}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelContextElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelContextElement.java
@@ -11,6 +11,7 @@
 package org.fusesource.ide.camel.model.service.core.model;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.fusesource.ide.camel.model.service.core.internal.CamelModelServiceCoreActivator;
@@ -24,7 +25,7 @@ import org.w3c.dom.NodeList;
  * 
  * @author lhein
  */
-public class CamelContextElement extends CamelModelElement {
+public class CamelContextElement extends AbstractCamelModelElement {
 	
 	public static final String ATTR_Id = "id";
 	public static final String ATTR_UseMDCLogging = "useMDCLogging";
@@ -33,12 +34,12 @@ public class CamelContextElement extends CamelModelElement {
 	/**
 	 * contains endpoint definitions stored using their ID value
 	 */
-	private Map<String, CamelModelElement> endpointDefinitions = new HashMap<String, CamelModelElement>();
+	private Map<String, AbstractCamelModelElement> endpointDefinitions = new HashMap<String, AbstractCamelModelElement>();
 	
 	/**
 	 * contains the dataformat definitions stored using their ID value
 	 */
-	private Map<String, CamelModelElement> dataformats = new HashMap<String, CamelModelElement>();
+	private Map<String, AbstractCamelModelElement> dataformats = new HashMap<String, AbstractCamelModelElement>();
 	
 	/**
 	 * 
@@ -50,14 +51,14 @@ public class CamelContextElement extends CamelModelElement {
 	/**
 	 * @return the endpointDefinitions
 	 */
-	public Map<String, CamelModelElement> getEndpointDefinitions() {
+	public Map<String, AbstractCamelModelElement> getEndpointDefinitions() {
 		return this.endpointDefinitions;
 	}
 	
 	/**
 	 * @param endpointDefinitions the endpointDefinitions to set
 	 */
-	public void setEndpointDefinitions(Map<String, CamelModelElement> endpointDefinitions) {
+	public void setEndpointDefinitions(Map<String, AbstractCamelModelElement> endpointDefinitions) {
 		this.endpointDefinitions = endpointDefinitions;
 	}
 
@@ -66,7 +67,7 @@ public class CamelContextElement extends CamelModelElement {
 	 * 
 	 * @param def
 	 */
-	public void addEndpointDefinition(CamelModelElement def) {
+	public void addEndpointDefinition(AbstractCamelModelElement def) {
 		if (this.endpointDefinitions.containsKey(def.getId())) return;
 		this.endpointDefinitions.put(def.getId(), def);
 		boolean childExists = false;
@@ -91,7 +92,7 @@ public class CamelContextElement extends CamelModelElement {
 	 * 
 	 * @param def
 	 */
-	public void removeEndpointDefinition(CamelModelElement def) {
+	public void removeEndpointDefinition(AbstractCamelModelElement def) {
 		if (this.endpointDefinitions.containsKey(def.getId())) {
 			this.endpointDefinitions.remove(def.getId());
 			boolean childExists = false;
@@ -117,14 +118,14 @@ public class CamelContextElement extends CamelModelElement {
 	/**
 	 * @return the dataformats
 	 */
-	public Map<String, CamelModelElement> getDataformats() {
+	public Map<String, AbstractCamelModelElement> getDataformats() {
 		return this.dataformats;
 	}
 	
 	/**
 	 * @param dataformats the dataformats to set
 	 */
-	public void setDataformats(Map<String, CamelModelElement> dataformats) {
+	public void setDataformats(Map<String, AbstractCamelModelElement> dataformats) {
 		this.dataformats = dataformats;
 	}
 	
@@ -133,7 +134,7 @@ public class CamelContextElement extends CamelModelElement {
 	 * 
 	 * @param df
 	 */
-	public void addDataFormat(CamelModelElement df) {
+	public void addDataFormat(AbstractCamelModelElement df) {
 		if (this.dataformats.containsKey(df.getId())) return;
 		this.dataformats.put((String)df.getId(), df);
 		boolean childExists = false;
@@ -172,7 +173,7 @@ public class CamelContextElement extends CamelModelElement {
 	 * 
 	 * @param df
 	 */
-	public void removeDataFormat(CamelModelElement df) {
+	public void removeDataFormat(AbstractCamelModelElement df) {
 		if (this.dataformats.containsKey(df.getId())) {
 			this.dataformats.remove(df.getId());
 			Node dataFormatsNode = null;
@@ -234,7 +235,7 @@ public class CamelContextElement extends CamelModelElement {
 	 * @see org.fusesource.ide.camel.model.service.core.model.CamelModelElement#ensureUniqueID(org.fusesource.ide.camel.model.service.core.model.CamelModelElement)
 	 */
 	@Override
-	public void ensureUniqueID(CamelModelElement elem) {
+	public void ensureUniqueID(AbstractCamelModelElement elem) {
 		super.ensureUniqueID(elem);
 	}
 	
@@ -271,12 +272,12 @@ public class CamelContextElement extends CamelModelElement {
 				for (int y=0; y<dfs.getLength(); y++) {
 					Node tmp_df = dfs.item(y);
 					if (tmp_df.getNodeType() != Node.ELEMENT_NODE) continue;
-					CamelModelElement cme = new CamelModelElement(this, tmp_df);
+					CamelBasicModelElement cme = new CamelBasicModelElement(this, tmp_df);
 					cme.initialize();
 					this.dataformats.put(cme.getId(), cme);
 				}
 			} else if (CamelUtils.getTranslatedNodeName(tmp).equals(ENDPOINT_NODE_NAME)) {
-				CamelModelElement cme = new CamelModelElement(this, tmp);
+				CamelBasicModelElement cme = new CamelBasicModelElement(this, tmp);
 				cme.initialize();
 				this.endpointDefinitions.put(cme.getId(), cme);
 			} else if (CamelUtils.getTranslatedNodeName(tmp).equals(ROUTE_NODE_NAME)) {
@@ -289,6 +290,37 @@ public class CamelContextElement extends CamelModelElement {
 		}
 	}
 	
+	public List<AbstractCamelModelElement> findAllNodesWithId(String nodeId) {
+		List<AbstractCamelModelElement> result = super.findAllNodesWithId(nodeId);
+		if (getDataformats().containsKey(nodeId)) {
+			result.add(getDataformats().get(nodeId));
+		}
+		if (getEndpointDefinitions().containsKey(nodeId)) {
+			result.add(getEndpointDefinitions().get(nodeId));
+		}
+		return result;
+	}
+
+	/**
+	 * searches the model for a node with the given id
+	 * 
+	 * @param nodeId
+	 * @return the node or null
+	 */
+	public AbstractCamelModelElement findNode(String nodeId) {
+		AbstractCamelModelElement res = super.findNode(nodeId);
+		if (res != null) {
+			return res;
+		}
+		if (getDataformats().containsKey(nodeId)) {
+			return getDataformats().get(nodeId);
+		}
+		if (getEndpointDefinitions().containsKey(nodeId)) {
+			return getEndpointDefinitions().get(nodeId);
+		}
+		return null;
+	}
+
 	/* (non-Javadoc)
 	 * @see org.fusesource.ide.camel.model.service.core.model.CamelModelElement#getCamelContext()
 	 */

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelElementConnection.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelElementConnection.java
@@ -15,7 +15,7 @@ import org.w3c.dom.Node;
 /**
  * @author lhein
  */
-public class CamelElementConnection extends CamelModelElement {
+public class CamelElementConnection extends AbstractCamelModelElement {
 	/**
 	 * True, if the connection is attached to its endpoints.
 	 */
@@ -24,12 +24,12 @@ public class CamelElementConnection extends CamelModelElement {
 	/**
 	 * Connection's source endpoint.
 	 */
-	private CamelModelElement source;
+	private AbstractCamelModelElement source;
 
 	/**
 	 * Connection's target endpoint.
 	 */
-	private CamelModelElement target;
+	private AbstractCamelModelElement target;
 
 	/**
 	 * Create a (solid) connection between two distinct shapes.
@@ -42,7 +42,7 @@ public class CamelElementConnection extends CamelModelElement {
 	 *             if any of the parameters are null or source == target
 	 * @see #setLineStyle(int)
 	 */
-	public CamelElementConnection(CamelModelElement source, CamelModelElement target) {
+	public CamelElementConnection(AbstractCamelModelElement source, AbstractCamelModelElement target) {
 		super(null, null);
 		if (source == null) {
 			throw new IllegalArgumentException("No source for Flow");
@@ -103,7 +103,7 @@ public class CamelElementConnection extends CamelModelElement {
 	 * 
 	 * @return a non-null GenericObject instance
 	 */
-	public CamelModelElement getSource() {
+	public AbstractCamelModelElement getSource() {
 		return source;
 	}
 
@@ -112,7 +112,7 @@ public class CamelElementConnection extends CamelModelElement {
 	 * 
 	 * @return a non-null GenericObject instance
 	 */
-	public CamelModelElement getTarget() {
+	public AbstractCamelModelElement getTarget() {
 		return target;
 	}
 
@@ -146,7 +146,7 @@ public class CamelElementConnection extends CamelModelElement {
 	 * @throws IllegalArgumentException
 	 *             if any of the paramers are null or newSource == newTarget
 	 */
-	public void reconnect(CamelModelElement newSource, CamelModelElement newTarget) {
+	public void reconnect(AbstractCamelModelElement newSource, AbstractCamelModelElement newTarget) {
 		if (newSource == null || newTarget == null || newSource == newTarget) {
 			throw new IllegalArgumentException();
 		}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelEndpoint.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelEndpoint.java
@@ -15,7 +15,7 @@ import org.fusesource.ide.foundation.core.xml.XmlEscapeUtility;
 /**
  * @author lhein
  */
-public class CamelEndpoint extends CamelModelElement {
+public class CamelEndpoint extends AbstractCamelModelElement implements IFuseDetailsPropertyContributor {
 
 	/**
 	 * @param parent
@@ -48,7 +48,7 @@ public class CamelEndpoint extends CamelModelElement {
 	 * @see org.fusesource.ide.camel.model.service.core.model.CamelModelElement#setParent(org.fusesource.ide.camel.model.service.core.model.CamelModelElement)
 	 */
 	@Override
-	public void setParent(CamelModelElement parent) {
+	public void setParent(AbstractCamelModelElement parent) {
 		super.setParent(parent);
 		if (parent != null && parent.getXmlNode() != null && getXmlNode() != null) {
 			boolean alreadyChild = false;

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelFile.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelFile.java
@@ -41,7 +41,7 @@ import org.xml.sax.Locator;
  * 
  * @author lhein
  */
-public class CamelFile extends CamelModelElement implements EventListener {
+public class CamelFile extends AbstractCamelModelElement implements EventListener {
 	
 	public static final int XML_INDENT_VALUE = 3;
 	
@@ -338,7 +338,7 @@ public class CamelFile extends CamelModelElement implements EventListener {
 	 */
 	@Override
 	public CamelContextElement getCamelContext() {
-		for (CamelModelElement e : getChildElements()) {
+		for (AbstractCamelModelElement e : getChildElements()) {
 			String translatedNodeName = e.getTranslatedNodeName();
 			if (translatedNodeName.equalsIgnoreCase("camelContext") || translatedNodeName.equalsIgnoreCase("routes")) {
 				return (CamelContextElement) e;

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelRouteElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelRouteElement.java
@@ -18,17 +18,17 @@ import org.w3c.dom.Node;
 /**
  * @author lhein
  */
-public class CamelRouteElement extends CamelModelElement {
+public class CamelRouteElement extends AbstractCamelModelElement implements IFuseDetailsPropertyContributor {
 	
 	/**
 	 * contains all inputs of the route
 	 */
-	private List<CamelModelElement> inputs = new ArrayList<CamelModelElement>();
+	private List<AbstractCamelModelElement> inputs = new ArrayList<AbstractCamelModelElement>();
 	
 	/**
 	 * contains all outputs of the route
 	 */
-	private List<CamelModelElement> outputs = new ArrayList<CamelModelElement>();
+	private List<AbstractCamelModelElement> outputs = new ArrayList<AbstractCamelModelElement>();
 	
 	/**
 	 * 
@@ -44,7 +44,7 @@ public class CamelRouteElement extends CamelModelElement {
 		super.parseChildren();
 		inputs.clear();
 		outputs.clear();
-		for (CamelModelElement c : getChildElements()) {
+		for (AbstractCamelModelElement c : getChildElements()) {
 			if (c.getNodeTypeId().equalsIgnoreCase("from")) {
 				inputs.add(c);
 			} else {
@@ -56,14 +56,14 @@ public class CamelRouteElement extends CamelModelElement {
 	/**
 	 * @return the inputs
 	 */
-	public List<CamelModelElement> getInputs() {
+	public List<AbstractCamelModelElement> getInputs() {
 		return this.inputs;
 	}
 	
 	/**
 	 * @return the outputs
 	 */
-	public List<CamelModelElement> getOutputs() {
+	public List<AbstractCamelModelElement> getOutputs() {
 		return this.outputs;
 	}
 	

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/IFuseDetailsPropertyContributor.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/IFuseDetailsPropertyContributor.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.camel.model.service.core.model;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public interface IFuseDetailsPropertyContributor {
+
+}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/PropertiesUtils.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/PropertiesUtils.java
@@ -32,7 +32,7 @@ import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.fusesource.ide.camel.model.service.core.catalog.UriParameterKind;
 import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -52,7 +52,7 @@ public class PropertiesUtils {
 		return null;
 	}
 	
-	public static Component getComponentFor(CamelModelElement selectedEP) {
+	public static Component getComponentFor(AbstractCamelModelElement selectedEP) {
 		if (selectedEP != null && selectedEP.getParameter("uri") != null) {
             int protocolSeparatorIdx = ((String)selectedEP.getParameter("uri")).indexOf(":");
             if (protocolSeparatorIdx != -1) {
@@ -63,14 +63,14 @@ public class PropertiesUtils {
 		return null;
 	}
 	
-	public static Eip getEipFor(CamelModelElement selectedEP) {
+	public static Eip getEipFor(AbstractCamelModelElement selectedEP) {
 		if (selectedEP != null && selectedEP.getUnderlyingMetaModelObject() != null) {
             return selectedEP.getUnderlyingMetaModelObject();
 		}
 		return null;
 	}
 		
-	public static List<Parameter> getPathProperties(CamelModelElement selectedEP) {
+	public static List<Parameter> getPathProperties(AbstractCamelModelElement selectedEP) {
 		ArrayList<Parameter> result = new ArrayList<Parameter>();
 
         if (selectedEP != null && selectedEP.getParameter("uri") != null) {
@@ -96,7 +96,7 @@ public class PropertiesUtils {
      * @param kind
      * @return
      */
-    public static List<Parameter> getPropertiesFor(CamelModelElement selectedEP, UriParameterKind kind) {
+    public static List<Parameter> getPropertiesFor(AbstractCamelModelElement selectedEP, UriParameterKind kind) {
         ArrayList<Parameter> result = new ArrayList<Parameter>();
 
         if (selectedEP != null && selectedEP.getParameter("uri") != null) {
@@ -132,7 +132,7 @@ public class PropertiesUtils {
      * @param selectedEP
      * @return
      */
-    public static List<Parameter> getComponentPropertiesFor(CamelModelElement selectedEP) {
+    public static List<Parameter> getComponentPropertiesFor(AbstractCamelModelElement selectedEP) {
         if (selectedEP != null && selectedEP.getParameter("uri") != null) {
             int protocolSeparatorIdx = ((String)selectedEP.getParameter("uri")).indexOf(":");
             if (protocolSeparatorIdx != -1) {
@@ -174,7 +174,7 @@ public class PropertiesUtils {
      * @param kind
      * @return
      */
-    public static List<Parameter> getPropertiesFor(CamelModelElement selectedEP) {
+    public static List<Parameter> getPropertiesFor(AbstractCamelModelElement selectedEP) {
         ArrayList<Parameter> result = new ArrayList<Parameter>();
 
         if (selectedEP != null && selectedEP.getUnderlyingMetaModelObject() != null) {
@@ -191,7 +191,7 @@ public class PropertiesUtils {
      * @param p
      * @return
      */
-    public static String getPropertyFromUri(CamelModelElement selectedEP, Parameter p, Component c) {
+    public static String getPropertyFromUri(AbstractCamelModelElement selectedEP, Parameter p, Component c) {
     	// we need to distinguish between parameters in the uri part after the ? char
     	final String kind = p.getKind();
 		final String uriParameterValue = (String)selectedEP.getParameter("uri");
@@ -279,7 +279,7 @@ public class PropertiesUtils {
      * @param c
      * @return
      */
-    private static Map<String, String> getPathMap(CamelModelElement selectedEP, Component c) {
+    private static Map<String, String> getPathMap(AbstractCamelModelElement selectedEP, Component c) {
     	HashMap<String, String> retVal = new HashMap<String, String>();
 
     	// get all path params
@@ -347,7 +347,7 @@ public class PropertiesUtils {
      * @param p
      * @return
      */
-    public static Object getTypedPropertyFromUri(CamelModelElement selectedEP, Parameter p, Component c) {
+    public static Object getTypedPropertyFromUri(AbstractCamelModelElement selectedEP, Parameter p, Component c) {
         String val = getPropertyFromUri(selectedEP, p, c);
 
         if (CamelComponentUtils.isBooleanProperty(p)) {
@@ -371,7 +371,7 @@ public class PropertiesUtils {
      * @param p
      * @param value
      */
-    public static void updateURIParams(CamelModelElement selectedEP, Parameter p, Object value, Component c, IObservableMap modelMap) {
+    public static void updateURIParams(AbstractCamelModelElement selectedEP, Parameter p, Object value, Component c, IObservableMap modelMap) {
     	if (p.getKind().equalsIgnoreCase("path")) {
     		// simply rebuild the uri
     		String newUri = "";
@@ -447,7 +447,7 @@ public class PropertiesUtils {
     	}
     }
     
-    public static String getUsedProtocol(CamelModelElement selectedEP) {
+    public static String getUsedProtocol(AbstractCamelModelElement selectedEP) {
         return ((String)selectedEP.getParameter("uri")).substring(0, ((String)selectedEP.getParameter("uri")).indexOf(':'));
     }
     

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/BasicUriValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/BasicUriValidator.java
@@ -13,7 +13,7 @@ package org.fusesource.ide.camel.validation;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -25,7 +25,7 @@ public class BasicUriValidator implements ValidationSupport {
      * @see org.fusesource.ide.camel.editor.validation.ValidationSupport#validate(org.fusesource.ide.camel.model.service.core.model.CamelModelElement)
      */
     @Override
-    public ValidationResult validate(CamelModelElement node) {
+    public ValidationResult validate(AbstractCamelModelElement node) {
         ValidationResult res = new ValidationResult();
         
         final String underlyingModelName = node.getUnderlyingMetaModelObject().getName();

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/ValidationFactory.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/ValidationFactory.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.validation.diagram.BasicNodeValidator;
 
 
@@ -24,12 +24,12 @@ import org.fusesource.ide.camel.validation.diagram.BasicNodeValidator;
  */
 public final class ValidationFactory {
 	
-	private static Map<Class<? extends CamelModelElement>, ValidationSupport> registeredValidators = new HashMap<Class<? extends CamelModelElement>, ValidationSupport>();
+	private static Map<Class<? extends AbstractCamelModelElement>, ValidationSupport> registeredValidators = new HashMap<Class<? extends AbstractCamelModelElement>, ValidationSupport>();
 	private static ValidationFactory instance;
 	
 	static {
 		// register a general validator which should basically work for mandatory field checking
-		registeredValidators.put(CamelModelElement.class, new BasicNodeValidator());
+		registeredValidators.put(AbstractCamelModelElement.class, new BasicNodeValidator());
 		// you may register special validators for specific model classes here but they all need to implement IValidationSupport
 		// ...
         //registeredValidators.put(Endpoint.class, new BasicUriValidator());
@@ -54,17 +54,17 @@ public final class ValidationFactory {
      * @param node
      * @return
      */
-    public ValidationResult validate(CamelModelElement node) {
+    public ValidationResult validate(AbstractCamelModelElement node) {
     	ValidationResult result = null;
     	
-    	Iterator<Class<? extends CamelModelElement>> it = registeredValidators.keySet().iterator();
+    	Iterator<Class<? extends AbstractCamelModelElement>> it = registeredValidators.keySet().iterator();
     	while (it.hasNext()) {
-			Class<? extends CamelModelElement> c = it.next();
+			Class<? extends AbstractCamelModelElement> c = it.next();
     	    
     	    if (c.isInstance(node)) {
                 ValidationSupport validator = registeredValidators.get(c);
                 if (validator == null) {
-                    validator = registeredValidators.get(CamelModelElement.class);
+                    validator = registeredValidators.get(AbstractCamelModelElement.class);
                 } 
                 result = validator.validate(node);
     	    }

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/ValidationSupport.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/ValidationSupport.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package org.fusesource.ide.camel.validation;
 
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -23,5 +23,5 @@ public interface ValidationSupport {
      * @param node
      * @return
      */
-    ValidationResult validate(CamelModelElement node);
+    ValidationResult validate(AbstractCamelModelElement node);
 }

--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/xml/XMLCamelRoutesValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/xml/XMLCamelRoutesValidator.java
@@ -19,7 +19,7 @@ import org.eclipse.wst.validation.ValidationResult;
 import org.eclipse.wst.validation.ValidationState;
 import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.validation.diagram.BasicNodeValidator;
 import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
 
@@ -70,7 +70,7 @@ public class XMLCamelRoutesValidator extends AbstractValidator {
 	 * @param resource
 	 */
 	private void checkCamelFile(CamelFile camelFile, ValidationResult validationResult, IResource resource) {
-		for (CamelModelElement cme : camelFile.getChildElements()) {
+		for (AbstractCamelModelElement cme : camelFile.getChildElements()) {
 			checkCamelModelElement(cme, validationResult, resource);
 		}
 	}
@@ -81,10 +81,10 @@ public class XMLCamelRoutesValidator extends AbstractValidator {
 	 * @param resource
 	 * @param locator
 	 */
-	private void checkCamelModelElement(CamelModelElement cme, ValidationResult validationResult, IResource resource) {
+	private void checkCamelModelElement(AbstractCamelModelElement cme, ValidationResult validationResult, IResource resource) {
 		org.fusesource.ide.camel.validation.ValidationResult result = new BasicNodeValidator().validate(cme);
 		validationResult.incrementError(result.getErrors().size());
-		for (CamelModelElement cmeChild : cme.getChildElements()) {
+		for (AbstractCamelModelElement cmeChild : cme.getChildElements()) {
 			checkCamelModelElement(cmeChild, validationResult, resource);
 		}
 	}

--- a/editor/plugins/org.fusesource.ide.branding/src/org/fusesource/ide/branding/wizards/NewCamelTestWizardPageTwo.java
+++ b/editor/plugins/org.fusesource.ide.branding/src/org/fusesource/ide/branding/wizards/NewCamelTestWizardPageTwo.java
@@ -46,7 +46,7 @@ import org.fusesource.ide.branding.RiderHelpContextIds;
 import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.foundation.core.util.URIs;
 
@@ -373,10 +373,10 @@ public class NewCamelTestWizardPageTwo extends WizardPage {
 		return root;
 	}
 
-	private List<CamelModelElement> getInputs(CamelContextElement context) {
-		ArrayList<CamelModelElement> eps = new ArrayList<CamelModelElement>();
+	private List<AbstractCamelModelElement> getInputs(CamelContextElement context) {
+		ArrayList<AbstractCamelModelElement> eps = new ArrayList<AbstractCamelModelElement>();
 		
-		for (CamelModelElement route : context.getChildElements()) {
+		for (AbstractCamelModelElement route : context.getChildElements()) {
 			if (route instanceof CamelRouteElement) {
 				CamelRouteElement r = (CamelRouteElement)route;
 				eps.addAll(r.getInputs());				
@@ -386,10 +386,10 @@ public class NewCamelTestWizardPageTwo extends WizardPage {
 		return eps;
 	}
 	
-	private List<CamelModelElement> getOutputs(CamelContextElement context) {
-		ArrayList<CamelModelElement> eps = new ArrayList<CamelModelElement>();
+	private List<AbstractCamelModelElement> getOutputs(CamelContextElement context) {
+		ArrayList<AbstractCamelModelElement> eps = new ArrayList<AbstractCamelModelElement>();
 		
-		for (CamelModelElement route : context.getChildElements()) {
+		for (AbstractCamelModelElement route : context.getChildElements()) {
 			if (route instanceof CamelRouteElement) {
 				CamelRouteElement r = (CamelRouteElement)route;
 				collectEndpoints(r.getOutputs(), eps);				
@@ -399,8 +399,8 @@ public class NewCamelTestWizardPageTwo extends WizardPage {
 		return eps;
 	}
 	
-	private void collectEndpoints(List<CamelModelElement> searchList, List<CamelModelElement> resultList) {
-		for (CamelModelElement cme : searchList) {
+	private void collectEndpoints(List<AbstractCamelModelElement> searchList, List<AbstractCamelModelElement> resultList) {
+		for (AbstractCamelModelElement cme : searchList) {
 			if (cme.isEndpointElement()) resultList.add(cme);
 			if (cme.getChildElements().isEmpty() == false) collectEndpoints(cme.getChildElements(), resultList);
 		}
@@ -443,9 +443,9 @@ public class NewCamelTestWizardPageTwo extends WizardPage {
 		fInputEndpointsTree.setCheckedElements((Object[]) fInputEndpointsTree.getInput());
 	}
 
-	private void setChildren(TreeNode node, List<CamelModelElement> endpointList, boolean input) {
+	private void setChildren(TreeNode node, List<AbstractCamelModelElement> endpointList, boolean input) {
 		List<TreeNode> children = new ArrayList<TreeNode>();
-		for (CamelModelElement e : endpointList) {
+		for (AbstractCamelModelElement e : endpointList) {
 			if (e.isEndpointElement() == false) continue; 
 			TreeNode child = new EndpointTreeNode(e.getParameter("uri"), input);
 			child.setParent(node);

--- a/editor/plugins/org.fusesource.ide.camel.editor/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.camel.editor/plugin.xml
@@ -110,7 +110,7 @@
                class="org.fusesource.ide.camel.editor.properties.DetailsSection"
                id="org.fusesource.ide.camel.editor.propertysheet.DetailsSection"
                tab="DefaultCamelPropertiesTab">
-            <input type="org.fusesource.ide.camel.model.service.core.model.CamelModelElement"/>
+            <input type="org.fusesource.ide.camel.model.service.core.model.IFuseDetailsPropertyContributor"/>
          </propertySection>
          <propertySection
                class="org.fusesource.ide.camel.editor.properties.AdvancedEndpointPropertiesSection"
@@ -123,7 +123,7 @@
                class="org.fusesource.ide.camel.editor.properties.DocumentationSection"
                id="DocumentationSection"
                tab="DocumentationTab">
-            <input type="org.fusesource.ide.camel.model.service.core.model.CamelModelElement"/>
+            <input type="org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement"/>
          </propertySection>
       </propertySections>
    </extension>   

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
@@ -77,7 +77,7 @@ import org.fusesource.ide.camel.editor.utils.INodeViewer;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.ICamelModelListener;
 import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
 import org.fusesource.ide.foundation.core.util.Objects;
@@ -105,8 +105,8 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	private CamelDiagramBehaviour camelDiagramBehaviour;
 	private CamelDesignEditorFlyoutPaletteComposite paletteComposite;
 	private CamelFile model;
-	private CamelModelElement selectedContainer;
-	private CamelModelElement highlightedNodeInDebugger;
+	private AbstractCamelModelElement selectedContainer;
+	private AbstractCamelModelElement highlightedNodeInDebugger;
 	private AbstractEditPart selectedEditPart;
 	private AbstractEditPart lastSelectedEditPart;
 	private KeyHandler keyHandler;
@@ -272,15 +272,15 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 				Object firstElement = structuredSelection.getFirstElement();
 				
 				/** this handles selections in the outline view -> selects the node in diagram **/
-				if (firstElement instanceof CamelModelElement) {
-					CamelModelElement node = (CamelModelElement)firstElement;
+				if (firstElement instanceof AbstractCamelModelElement) {
+					AbstractCamelModelElement node = (AbstractCamelModelElement)firstElement;
 					if (node != null) {
 						if (node instanceof CamelContextElement == false) setSelectedNode(node);
 					}
 				
 				/** this handles selections in the diagram -> selects node in outline view **/
 				} else if (firstElement instanceof ContainerShapeEditPart) {
-					CamelModelElement node = NodeUtils.toCamelElement(firstElement);
+					AbstractCamelModelElement node = NodeUtils.toCamelElement(firstElement);
 					if (node != null) {
 						this.outlinePage.setOutlineSelection(node);
 					}
@@ -445,7 +445,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	/**
 	 * @return the selectedContainer
 	 */
-	public CamelModelElement getSelectedContainer() {
+	public AbstractCamelModelElement getSelectedContainer() {
 		return this.selectedContainer;
 	}
 	
@@ -454,7 +454,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	 * 
 	 * @param route
 	 */
-	public void setSelectedContainer(CamelModelElement route) {
+	public void setSelectedContainer(AbstractCamelModelElement route) {
 		this.selectedContainer = route;
 		switchContainer();
 	}
@@ -467,7 +467,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 			@Override
 			public void run() {
 				parent.stopDirtyListener();
-				CamelModelElement container = getSelectedContainer() != null ? getSelectedContainer() : getModel();
+				AbstractCamelModelElement container = getSelectedContainer() != null ? getSelectedContainer() : getModel();
 				// reimport diagram contents
 				ImportCamelContextElementsCommand importCommand = new ImportCamelContextElementsCommand(CamelDesignEditor.this, getEditingDomain(), container, null);
 		        getEditingDomain().getCommandStack().execute(importCommand);
@@ -603,7 +603,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	/**
 	 * @return the highlightedNodeInDebugger
 	 */
-	public synchronized CamelModelElement getHighlightedNodeInDebugger() {
+	public synchronized AbstractCamelModelElement getHighlightedNodeInDebugger() {
 		return this.highlightedNodeInDebugger;
 	}
 	
@@ -614,7 +614,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	 */
 	private synchronized void highlightBreakpointNodeWithID(String endpointNodeId) {
 		// get the correct node for the id
-		final CamelModelElement node = getModel().findNode(endpointNodeId);
+		final AbstractCamelModelElement node = getModel().findNode(endpointNodeId);
 		
 		if (node == null) return;
 		if (this.highlightedNodeInDebugger != null && node.getId() != null && node.getId().equals(highlightedNodeInDebugger.getId())) return;
@@ -643,7 +643,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	 * @param bo			the node
 	 * @param highlight		the highlight status
 	 */
-	private synchronized void setDebugHighLight(CamelModelElement bo, boolean highlight) {
+	private synchronized void setDebugHighLight(AbstractCamelModelElement bo, boolean highlight) {
 		if (bo == null) return;
 		
 		// delegate to an operation command for async transacted diagram update
@@ -658,7 +658,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	 * @see org.fusesource.ide.camel.editor.utils.INodeViewer#getSelectedNode()
 	 */
 	@Override
-	public CamelModelElement getSelectedNode() {
+	public AbstractCamelModelElement getSelectedNode() {
 		return NodeUtils.getSelectedNode(Selections.getSelection(getEditorSite()));
 	}
 	
@@ -666,7 +666,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	 * Finds the given node by walking the edit part tree looking for the correct one
 	 */
 	@SuppressWarnings("unchecked")
-	public static EditPart findEditPart(CamelModelElement node, EditPart part) {
+	public static EditPart findEditPart(AbstractCamelModelElement node, EditPart part) {
 		if (part instanceof RootEditPart) {
 			RootEditPart root = (RootEditPart) part;
 			EditPart contents = root.getContents();
@@ -676,7 +676,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 		}
 		if (part instanceof EditPart) {
 			EditPart nodeEditPart = part;
-			CamelModelElement modelNode = NodeUtils.toCamelElement(nodeEditPart);
+			AbstractCamelModelElement modelNode = NodeUtils.toCamelElement(nodeEditPart);
 			if (Objects.equal(node, modelNode) || node.getId().equals(modelNode.getId())) {
 				return nodeEditPart;
 			}
@@ -695,7 +695,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 	 * @see org.fusesource.ide.camel.editor.utils.INodeViewer#setSelectedNode(org.fusesource.ide.camel.model.service.core.model.CamelModelElement)
 	 */
 	@Override
-	public void setSelectedNode(CamelModelElement newSelection) {
+	public void setSelectedNode(AbstractCamelModelElement newSelection) {
 		if (newSelection != null) {
 			Object editPart = getGraphicalViewer().getEditPartRegistry().get(getFeatureProvider().getPictogramElementForBusinessObject(newSelection));
 			if (editPart != null) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelEditor.java
@@ -62,7 +62,7 @@ import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.internal.UIMessages;
 import org.fusesource.ide.camel.editor.utils.DiagramUtils;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.ui.io.CamelContextNodeEditorInput;
 import org.fusesource.ide.foundation.ui.io.CamelXMLEditorInput;
 import org.fusesource.ide.foundation.ui.util.Selections;
@@ -547,11 +547,11 @@ public class CamelEditor extends MultiPageEditorPart implements IResourceChangeL
 	 * @param nodes
 	 * @return
 	 */
-	private boolean findUnconnectedNode(List<CamelModelElement> nodes) {
+	private boolean findUnconnectedNode(List<AbstractCamelModelElement> nodes) {
 		boolean unconnected = false;
 		int nodesWithoutInput = 0;
 		int nodesWithoutOutput = 0;
-		for (CamelModelElement node : nodes) {
+		for (AbstractCamelModelElement node : nodes) {
 			if (!node.getChildElements().isEmpty()) {
 				unconnected = findUnconnectedNode(node.getChildElements());
 				if (unconnected) return true;
@@ -643,7 +643,7 @@ public class CamelEditor extends MultiPageEditorPart implements IResourceChangeL
 					designEditor.setModel(designEditor.getModel().reloadModelFromXML(text));
 					// add the diagram contents
 					ImportCamelContextElementsCommand importCommand = new ImportCamelContextElementsCommand(designEditor, designEditor.getEditingDomain(),
-							(CamelModelElement) (getDesignEditor().getSelectedContainer() != null ? getDesignEditor().getSelectedContainer() : designEditor.getModel()), null);
+							(AbstractCamelModelElement) (getDesignEditor().getSelectedContainer() != null ? getDesignEditor().getSelectedContainer() : designEditor.getModel()), null);
 					designEditor.getEditingDomain().getCommandStack().execute(importCommand);
 					designEditor.initializeDiagram(importCommand.getDiagram());
 					designEditor.refreshDiagramContents(null);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelGlobalConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelGlobalConfigEditor.java
@@ -58,8 +58,9 @@ import org.fusesource.ide.camel.editor.provider.ext.GlobalConfigurationTypeWizar
 import org.fusesource.ide.camel.editor.provider.ext.ICustomGlobalConfigElementContribution;
 import org.fusesource.ide.camel.editor.utils.MavenUtils;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelBasicModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.ICamelModelListener;
 import org.fusesource.ide.foundation.core.util.CamelUtils;
 import org.fusesource.ide.foundation.core.util.Strings;
@@ -472,7 +473,7 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 
 			// we add all context wide endpoint elements
 			if (cf.getCamelContext() != null && cf.getCamelContext().getEndpointDefinitions() != null) {
-				for (CamelModelElement cme : cf.getCamelContext().getEndpointDefinitions().values()) {
+				for (AbstractCamelModelElement cme : cf.getCamelContext().getEndpointDefinitions().values()) {
 					boolean foundMatch = false;
 					for (GlobalConfigElementItem item : elementContributions) {
 						String catId = item.getCategoryId() != null && item.getCategoryId().trim().length()>0 ? item.getCategoryId() : DEFAULT_CAT_ID;
@@ -488,7 +489,7 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 
 			// we add all context wide data formats
 			if (cf.getCamelContext() != null && cf.getCamelContext().getDataformats() != null) {
-				for (CamelModelElement cme : cf.getCamelContext().getDataformats().values()) {
+				for (AbstractCamelModelElement cme : cf.getCamelContext().getDataformats().values()) {
 					boolean foundMatch = false;
 					for (GlobalConfigElementItem item : elementContributions) {
 						String catId = item.getCategoryId() != null && item.getCategoryId().trim().length()>0 ? item.getCategoryId() : DEFAULT_CAT_ID;
@@ -535,10 +536,12 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 								case GLOBAL_ELEMENT:		String id = ((Element)newXMLNode).getAttribute("id");
 															cf.addGlobalDefinition(Strings.isBlank(id) ? UUID.randomUUID().toString() : id, newXMLNode);	
 															break;
-								case CONTEXT_DATAFORMAT:	CamelModelElement elemDF = new CamelModelElement(cf.getCamelContext(), newXMLNode);
+							case CONTEXT_DATAFORMAT:
+								AbstractCamelModelElement elemDF = new CamelBasicModelElement(cf.getCamelContext(), newXMLNode);
 															cf.getCamelContext().addDataFormat(elemDF);
 															break;
-								case CONTEXT_ENDPOINT:		CamelModelElement elemEP = new CamelModelElement(cf.getCamelContext(), newXMLNode);
+							case CONTEXT_ENDPOINT:
+								AbstractCamelModelElement elemEP = new CamelBasicModelElement(cf.getCamelContext(), newXMLNode);
 															cf.getCamelContext().addEndpointDefinition(elemEP);
 															break;
 								default:					// ignore
@@ -566,7 +569,7 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 		if (this.treeViewer.getSelection().isEmpty() == false) {
 			IStructuredSelection sel = (IStructuredSelection)this.treeViewer.getSelection();
 			Object o = Selections.getFirstSelection(sel);
-			Element modElem = o instanceof Element ? (Element)o : o instanceof CamelModelElement ? (Element)((CamelModelElement)o).getXmlNode() : null; 
+			Element modElem = o instanceof Element ? (Element)o : o instanceof AbstractCamelModelElement ? (Element)((AbstractCamelModelElement)o).getXmlNode() : null; 
 			ICustomGlobalConfigElementContribution extHandler = getExtensionForElement(modElem);
 			if (extHandler != null) {
 				GlobalConfigurationTypeWizard wizard = extHandler.modifyGlobalElement(parentEditor.getDesignEditor().getModel().getDocument());
@@ -581,7 +584,7 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 					if (newXMLNode == null) return;
 					switch (extHandler.getGlobalConfigElementType()) {
 						case CONTEXT_DATAFORMAT:	// here we need to reinit the model element so it copies all information from the node
-						case CONTEXT_ENDPOINT:		CamelModelElement cme = (CamelModelElement)o;
+						case CONTEXT_ENDPOINT:		AbstractCamelModelElement cme = (AbstractCamelModelElement)o;
 													cme.initialize();
 													break;
 						case GLOBAL_ELEMENT:		
@@ -604,9 +607,9 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 				ICustomGlobalConfigElementContribution extHandler = null;
 				Element deletedNode = null;
 				try {
-					if (selObj instanceof CamelModelElement) {
+					if (selObj instanceof AbstractCamelModelElement) {
 						// either an endpoint or a data format definition
-						CamelModelElement cme = (CamelModelElement)selObj;
+						AbstractCamelModelElement cme = (AbstractCamelModelElement)selObj;
 						deletedNode = (Element)cme.getXmlNode();
 						extHandler = getExtensionForElement(deletedNode);
 						if (cme.isEndpointElement()) {
@@ -650,8 +653,8 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 		Element e = null;
 		if (element instanceof Element) {
 			e = (Element)element;
-		} else if (element instanceof CamelModelElement) {
-			e = (Element)((CamelModelElement)element).getXmlNode();
+		} else if (element instanceof AbstractCamelModelElement) {
+			e = (Element)((AbstractCamelModelElement)element).getXmlNode();
 		}
 		if (e != null) {
 			ICustomGlobalConfigElementContribution handler = getExtensionForElement(e);
@@ -786,8 +789,8 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 				if (!Strings.isEmpty(node.getAttribute("id"))) text.append(" (" + type + ") ", StyledString.COUNTER_STYLER);
 				cell.setText(text.toString());
 				cell.setStyleRanges(text.getStyleRanges());
-			} else if (element instanceof CamelModelElement) {
-				CamelModelElement cme = (CamelModelElement)element;
+			} else if (element instanceof AbstractCamelModelElement) {
+				AbstractCamelModelElement cme = (AbstractCamelModelElement)element;
 				Image img = getIconForElement(cme);
 				String type = Strings.capitalize(cme.getTranslatedNodeName());
 				for (GlobalConfigElementItem item : elementContributions) {
@@ -811,8 +814,8 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 		private Image getIconForElement(Object element) {
 			if (element instanceof Node) {
 				return CamelEditorUIActivator.getDefault().getImage("beandef.gif");
-			} else if (element instanceof CamelModelElement) {
-				CamelModelElement cme = (CamelModelElement)element;
+			} else if (element instanceof AbstractCamelModelElement) {
+				AbstractCamelModelElement cme = (AbstractCamelModelElement)element;
 				if (cme.getTranslatedNodeName().equalsIgnoreCase("endpoint")) {
 					return CamelEditorUIActivator.getDefault().getImage("endpointdef.png");	
 				} else if (CamelUtils.getTranslatedNodeName(cme.getXmlNode().getParentNode()).equalsIgnoreCase("dataFormats")) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/GoToMarkerForCamelEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/GoToMarkerForCamelEditor.java
@@ -17,7 +17,7 @@ import org.eclipse.ui.texteditor.MarkerUtilities;
 import org.eclipse.wst.sse.ui.StructuredTextEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
 
 /**
@@ -46,7 +46,7 @@ public class GoToMarkerForCamelEditor implements IGotoMarker {
 			if (id != null) {
 				final CamelDesignEditor designEditor = camelEditor.getDesignEditor();
 				CamelFile camelFile = designEditor.getModel();
-				CamelModelElement camelModelElement = camelFile.findNode(id);
+				AbstractCamelModelElement camelModelElement = camelFile.findNode(id);
 				if (camelModelElement != null) {
 					camelEditor.setActiveEditor(designEditor);
 					designEditor.setSelectedNode(camelModelElement);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/DeleteNodeCommand.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/DeleteNodeCommand.java
@@ -17,7 +17,7 @@ import org.eclipse.graphiti.features.IDeleteFeature;
 import org.eclipse.graphiti.features.context.impl.DeleteContext;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 
 /**
@@ -25,9 +25,9 @@ import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
  */
 public class DeleteNodeCommand extends RecordingCommand {
 	private final CamelDesignEditor designEditor;
-	private final CamelModelElement selectedNode;
+	private final AbstractCamelModelElement selectedNode;
 
-	public DeleteNodeCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, CamelModelElement selectedNode) {
+	public DeleteNodeCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, AbstractCamelModelElement selectedNode) {
 		super(editingDomain);
 		this.designEditor = designEditor;
 		this.selectedNode = selectedNode;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/DiagramOperations.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/DiagramOperations.java
@@ -23,7 +23,7 @@ import org.eclipse.graphiti.ui.services.GraphitiUi;
 import org.eclipse.swt.widgets.Display;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -59,7 +59,7 @@ public class DiagramOperations {
 		}
 	}
 
-	public static DeleteNodeCommand deleteNode(CamelDesignEditor designEditor, CamelModelElement selectedNode) {
+	public static DeleteNodeCommand deleteNode(CamelDesignEditor designEditor, AbstractCamelModelElement selectedNode) {
 		TransactionalEditingDomain editingDomain = createEditingDomain(designEditor);
 		DeleteNodeCommand operation = new DeleteNodeCommand(designEditor, editingDomain, selectedNode);
 		execute(editingDomain, operation, true);
@@ -123,7 +123,7 @@ public class DiagramOperations {
 		return operation;
 	}
 	
-	public static void highlightNode(final CamelDesignEditor designEditor, final CamelModelElement node,  final boolean highlight) {
+	public static void highlightNode(final CamelDesignEditor designEditor, final AbstractCamelModelElement node,  final boolean highlight) {
 		Display.getDefault().asyncExec(new Runnable() {
 			@Override
 			public void run() {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/HighlightNodeCommand.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/HighlightNodeCommand.java
@@ -22,7 +22,7 @@ import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.CamelEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.utils.StyleUtil;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 
 /**
@@ -31,10 +31,10 @@ import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 public class HighlightNodeCommand extends RecordingCommand {
 	
 	private final CamelDesignEditor designEditor;
-	private CamelModelElement node;
+	private AbstractCamelModelElement node;
 	private boolean highlight;
 
-	public HighlightNodeCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, CamelModelElement node, boolean highlight) {
+	public HighlightNodeCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, AbstractCamelModelElement node, boolean highlight) {
 		super(editingDomain);
 		this.designEditor = designEditor;
 		this.node = node;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/ImportCamelContextElementsCommand.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/ImportCamelContextElementsCommand.java
@@ -31,7 +31,7 @@ import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -40,7 +40,7 @@ public class ImportCamelContextElementsCommand extends RecordingCommand {
 
 	private TransactionalEditingDomain editingDomain;
 	private CamelDesignEditor designEditor;
-	private CamelModelElement container;
+	private AbstractCamelModelElement container;
 	private Resource createdResource;
 	private Diagram diagram;
 	private IFeatureProvider featureProvider;
@@ -79,7 +79,7 @@ public class ImportCamelContextElementsCommand extends RecordingCommand {
 	 * @param diagramName
 	 * @param camelContextFile
 	 */
-	public ImportCamelContextElementsCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, CamelModelElement container, Diagram diagram) {
+	public ImportCamelContextElementsCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, AbstractCamelModelElement container, Diagram diagram) {
 		super(editingDomain);
 		this.designEditor = designEditor;
 		this.editingDomain = editingDomain;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/UpdateCommand.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/UpdateCommand.java
@@ -17,7 +17,7 @@ import org.eclipse.graphiti.features.context.impl.UpdateContext;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -25,9 +25,9 @@ import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 public class UpdateCommand extends RecordingCommand {
 	
 	private final CamelDesignEditor designEditor;
-	private CamelModelElement node;
+	private AbstractCamelModelElement node;
 
-	public UpdateCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, CamelModelElement node) {
+	public UpdateCommand(CamelDesignEditor designEditor, TransactionalEditingDomain editingDomain, AbstractCamelModelElement node) {
 		super(editingDomain);
 		this.designEditor = designEditor;
 		this.node = node;
@@ -35,7 +35,7 @@ public class UpdateCommand extends RecordingCommand {
 
 	@Override
 	protected void doExecute() {
-		CamelModelElement selectedNode = this.node == null ? designEditor.getSelectedNode() : node;
+		AbstractCamelModelElement selectedNode = this.node == null ? designEditor.getSelectedNode() : node;
 		if (selectedNode == null) {
 			// use the route node in this case
 			selectedNode = designEditor.getModel().getCamelContext();
@@ -43,7 +43,7 @@ public class UpdateCommand extends RecordingCommand {
 		updateFigure(selectedNode);
 	}
 	
-	private void updateFigure(CamelModelElement node) {
+	private void updateFigure(AbstractCamelModelElement node) {
 		if (node == null) return;
 
 		PictogramElement pe = node instanceof CamelContextElement ? designEditor.getDiagramTypeProvider().getDiagram() : designEditor.getFeatureProvider().getPictogramElementForBusinessObject(node);
@@ -53,7 +53,7 @@ public class UpdateCommand extends RecordingCommand {
 		}
 		
 		// do check if underlying xml node changed / document changed
-		CamelModelElement bo2 = designEditor.getModel().findNode(node.getId());
+		AbstractCamelModelElement bo2 = designEditor.getModel().findNode(node.getId());
 		if (pe != null && bo2 != null && bo2.getXmlNode().isEqualNode(node.getXmlNode()) == false) {
 			designEditor.getFeatureProvider().link(pe, bo2);
 		}
@@ -61,7 +61,7 @@ public class UpdateCommand extends RecordingCommand {
 		UpdateContext ctx = new UpdateContext(pe);
 		IUpdateFeature updateFeature = designEditor.getFeatureProvider().getUpdateFeature(ctx);
 		updateFeature.update(ctx);
-		for (CamelModelElement elem : node.getChildElements()) {
+		for (AbstractCamelModelElement elem : node.getChildElements()) {
 			updateFigure(elem);
 		}
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/dialogs/ConditionalBreakpointEditorDialog.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/dialogs/ConditionalBreakpointEditorDialog.java
@@ -34,7 +34,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.fusesource.ide.camel.model.service.core.CamelServiceManagerUtil;
 import org.fusesource.ide.camel.model.service.core.ICamelManagerService;
 import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.util.LanguageUtils;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.preferences.PreferenceManager;
@@ -132,7 +132,7 @@ public class ConditionalBreakpointEditorDialog extends TitleAreaDialog {
 	
 	private String language;
 	private String condition;
-	private CamelModelElement node;
+	private AbstractCamelModelElement node;
 	private Group grp_language;
 	private Group grp_condition;
 	private Combo combo_language;
@@ -147,7 +147,7 @@ public class ConditionalBreakpointEditorDialog extends TitleAreaDialog {
 	 * @param parentShell
 	 * @param node
 	 */
-	public ConditionalBreakpointEditorDialog(Shell parentShell, CamelModelElement node) {
+	public ConditionalBreakpointEditorDialog(Shell parentShell, AbstractCamelModelElement node) {
 	    super(parentShell);
 	    this.node = node;
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/add/AddNodeFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/add/AddNodeFeature.java
@@ -21,7 +21,7 @@ import org.fusesource.ide.camel.editor.commands.DiagramOperations;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.editor.utils.FigureUIFactory;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -43,15 +43,15 @@ public class AddNodeFeature extends AbstractAddShapeFeature {
 	public boolean canAdd(IAddContext context) {
 		// check if user wants to add a EClass
 		final Object newObject = context.getNewObject();
-		if (newObject instanceof CamelModelElement) {
+		if (newObject instanceof AbstractCamelModelElement) {
 			// check if user wants to add to a diagram
 			if (context.getTargetContainer() instanceof Diagram) {
-                return ((CamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("route") ||
-                		((CamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("rest") ||
-                		((CamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("restConfiguration");
-            } else if (getBusinessObjectForPictogramElement(context.getTargetContainer()) instanceof CamelModelElement) {
-            	CamelModelElement container =  (CamelModelElement)getBusinessObjectForPictogramElement(context.getTargetContainer());
-            	CamelModelElement child = (CamelModelElement)newObject;
+                return ((AbstractCamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("route") ||
+                		((AbstractCamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("rest") ||
+                		((AbstractCamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("restConfiguration");
+            } else if (getBusinessObjectForPictogramElement(context.getTargetContainer()) instanceof AbstractCamelModelElement) {
+            	AbstractCamelModelElement container =  (AbstractCamelModelElement)getBusinessObjectForPictogramElement(context.getTargetContainer());
+            	AbstractCamelModelElement child = (AbstractCamelModelElement)newObject;
             	return NodeUtils.isValidChild(container, child);
             }
 		}
@@ -63,7 +63,7 @@ public class AddNodeFeature extends AbstractAddShapeFeature {
 	 */
 	@Override
 	public PictogramElement add(IAddContext context) {
-		CamelModelElement addedClass = (CamelModelElement)context.getNewObject();
+		AbstractCamelModelElement addedClass = (AbstractCamelModelElement)context.getNewObject();
 		ContainerShape targetContainer = (ContainerShape) context.getTargetContainer();
 		Diagram diagram = Graphiti.getPeService().getDiagramForPictogramElement(targetContainer);
 		String label = addedClass.getDisplayText();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/CreateFlowFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/CreateFlowFeature.java
@@ -19,7 +19,7 @@ import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
 import org.fusesource.ide.camel.editor.provider.ext.PaletteCategoryItemProvider;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -55,8 +55,8 @@ public class CreateFlowFeature extends AbstractCreateConnectionFeature implement
 	public boolean canCreate(ICreateConnectionContext context) {
 		// return true if both anchors belong to a EClass
 		// and those EClasses are not identical
-		CamelModelElement source = getNode(context.getSourceAnchor());
-		CamelModelElement target = getNode(context.getTargetAnchor());
+		AbstractCamelModelElement source = getNode(context.getSourceAnchor());
+		AbstractCamelModelElement target = getNode(context.getTargetAnchor());
 		
 		if (target != null && source != target) {
 			// if we only support a single output and we already have one then we can't connect to another output
@@ -89,8 +89,8 @@ public class CreateFlowFeature extends AbstractCreateConnectionFeature implement
 		Connection newConnection = null;
 
 		// get EClasses which should be connected
-		CamelModelElement source = getNode(context.getSourceAnchor());
-		CamelModelElement target = getNode(context.getTargetAnchor());
+		AbstractCamelModelElement source = getNode(context.getSourceAnchor());
+		AbstractCamelModelElement target = getNode(context.getTargetAnchor());
 
 		if (target != null) {
 			// create new business object
@@ -108,11 +108,11 @@ public class CreateFlowFeature extends AbstractCreateConnectionFeature implement
 	/**
 	 * Returns the EClass belonging to the anchor, or null if not available.
 	 */
-	private CamelModelElement getNode(Anchor anchor) {
+	private AbstractCamelModelElement getNode(Anchor anchor) {
 		if (anchor != null) {
 			Object obj = getBusinessObjectForPictogramElement(anchor.getParent());
-			if (obj instanceof CamelModelElement) {
-				return (CamelModelElement) obj;
+			if (obj instanceof AbstractCamelModelElement) {
+				return (AbstractCamelModelElement) obj;
 			}
 		}
 		return null;
@@ -121,7 +121,7 @@ public class CreateFlowFeature extends AbstractCreateConnectionFeature implement
 	/**
 	 * Creates a EReference between two EClasses.
 	 */
-	private CamelElementConnection createFlow(CamelModelElement source, CamelModelElement target) {
+	private CamelElementConnection createFlow(AbstractCamelModelElement source, AbstractCamelModelElement target) {
 		return new CamelElementConnection(source, target);
 	}
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateConnectorFigureFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateConnectorFigureFeature.java
@@ -18,7 +18,7 @@ import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
 import org.fusesource.ide.camel.model.service.core.model.CamelEndpoint;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.w3c.dom.Element;
 
@@ -61,7 +61,7 @@ public class CreateConnectorFigureFeature extends CreateFigureFeature {
      * @see org.fusesource.ide.camel.editor.features.create.ext.CreateFigureFeature#createNode(org.fusesource.ide.camel.model.service.core.model.CamelModelElement, boolean)
      */
     @Override
-    protected CamelModelElement createNode(CamelModelElement parent, boolean createDOMNode) {
+    protected AbstractCamelModelElement createNode(AbstractCamelModelElement parent, boolean createDOMNode) {
     	if( getEip() != null ) {
 			CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
 			if (editor.getModel() != null) { 

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateEndpointFigureFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateEndpointFigureFeature.java
@@ -20,7 +20,7 @@ import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
 import org.fusesource.ide.camel.model.service.core.model.CamelEndpoint;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.w3c.dom.Node;
 
 
@@ -37,7 +37,7 @@ public class CreateEndpointFigureFeature extends CreateFigureFeature {
 	 * @param deps	optional dependencies...if not applicable hand over null or empty list
 	 */
 	public CreateEndpointFigureFeature(IFeatureProvider fp, String name, String description, String endpointUri, List<Dependency> deps) {
-		super(fp, name, description, (Class<? extends CamelModelElement>)null);
+		super(fp, name, description, (Class<? extends AbstractCamelModelElement>)null);
 		this.endpointUri = endpointUri;
 		this.deps = deps;
 		setEip(getEipByName("to"));
@@ -55,7 +55,7 @@ public class CreateEndpointFigureFeature extends CreateFigureFeature {
 	 * @see org.fusesource.ide.camel.editor.features.create.ext.CreateFigureFeature#createNode(org.fusesource.ide.camel.model.service.core.model.CamelModelElement, boolean)
 	 */
 	@Override
-	protected CamelModelElement createNode(CamelModelElement parent, boolean createDOMNode) {
+	protected AbstractCamelModelElement createNode(AbstractCamelModelElement parent, boolean createDOMNode) {
 		CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
 		if (editor.getModel() != null) { 
 			Node newNode = null;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateFigureFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateFigureFeature.java
@@ -30,9 +30,10 @@ import org.fusesource.ide.camel.model.service.core.catalog.CamelModel;
 import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelBasicModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.w3c.dom.Node;
 
@@ -42,7 +43,7 @@ import org.w3c.dom.Node;
 public class CreateFigureFeature extends AbstractCreateFeature implements PaletteCategoryItemProvider {
 
 	private Eip eip;
-	private Class<? extends CamelModelElement> clazz;
+	private Class<? extends AbstractCamelModelElement> clazz;
 	
 	/**
 	 * 
@@ -63,7 +64,7 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 	 * @param description
 	 * @param clazz
 	 */
-	public CreateFigureFeature(IFeatureProvider fp, String name, String description, Class<? extends CamelModelElement> clazz) {
+	public CreateFigureFeature(IFeatureProvider fp, String name, String description, Class<? extends AbstractCamelModelElement> clazz) {
 		super(fp, name, description);
 		this.clazz = clazz;;
 	}
@@ -79,7 +80,7 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 		this.eip = eip;
 	}
 	
-	public Class<? extends CamelModelElement> getClazz() {
+	public Class<? extends AbstractCamelModelElement> getClazz() {
 		return clazz;
 	}
 	
@@ -120,25 +121,25 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 				eip.getName().equalsIgnoreCase("rest") || eip.getName().equalsIgnoreCase("restConfiguration");
 			if (clazz != null) { 
 				Object obj = newInstance(clazz);
-				if (obj != null && obj instanceof CamelModelElement) return ((CamelModelElement)obj).getNodeTypeId().equalsIgnoreCase("route");
+				if (obj != null && obj instanceof AbstractCamelModelElement) return ((AbstractCamelModelElement)obj).getNodeTypeId().equalsIgnoreCase("route");
 				return false;
 			}
-		} else if (containerBO instanceof CamelModelElement && ((CamelModelElement)containerBO).getNodeTypeId().equalsIgnoreCase("choice")) {
+		} else if (containerBO instanceof AbstractCamelModelElement && ((AbstractCamelModelElement)containerBO).getNodeTypeId().equalsIgnoreCase("choice")) {
 			// only one otherwise per choice
-			CamelModelElement choice = (CamelModelElement)containerBO;
+			AbstractCamelModelElement choice = (AbstractCamelModelElement)containerBO;
 			if (this.eip != null) {
 				if (this.eip.getName().equalsIgnoreCase("otherwise") && choice.getParameter("otherwise") != null) return false;
 				return this.eip.getName().equalsIgnoreCase("when") || this.eip.getName().equalsIgnoreCase("otherwise");
 			} else if (clazz != null) {
 				Object obj = newInstance(clazz);
-				if (obj instanceof CamelModelElement && ((CamelModelElement)obj).getNodeTypeId().equalsIgnoreCase("otherwise") && choice.getParameter("otherwise") != null) return false;
+				if (obj instanceof AbstractCamelModelElement && ((AbstractCamelModelElement)obj).getNodeTypeId().equalsIgnoreCase("otherwise") && choice.getParameter("otherwise") != null) return false;
 			}
 		}
 		
 		// we have to prevent some eips being dropped on the route even if camel catalog says its allowed
-		if (eip.getName().equalsIgnoreCase("when") || eip.getName().equalsIgnoreCase("otherwise") && containerBO != null && ((CamelModelElement)containerBO).getNodeTypeId().equalsIgnoreCase("choice") == false) return false;
+		if (eip.getName().equalsIgnoreCase("when") || eip.getName().equalsIgnoreCase("otherwise") && containerBO != null && ((AbstractCamelModelElement)containerBO).getNodeTypeId().equalsIgnoreCase("choice") == false) return false;
 		
-		return (containerBO != null && containerBO instanceof CamelModelElement && ((CamelModelElement)containerBO).getUnderlyingMetaModelObject().canHaveChildren() && ((CamelModelElement)containerBO).getUnderlyingMetaModelObject().getAllowedChildrenNodeTypes().contains(eip.getName()));
+		return (containerBO != null && containerBO instanceof AbstractCamelModelElement && ((AbstractCamelModelElement)containerBO).getUnderlyingMetaModelObject().canHaveChildren() && ((AbstractCamelModelElement)containerBO).getUnderlyingMetaModelObject().getAllowedChildrenNodeTypes().contains(eip.getName()));
 	}
 
 	/*
@@ -172,7 +173,7 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 	 */
 	protected String getIconName() {
 		String ret = null;
-		CamelModelElement node = createNode(null, false);
+		AbstractCamelModelElement node = createNode(null, false);
 		if(node != null ) {
 			ret = node.getIconName();
 		}
@@ -187,14 +188,14 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 	public Object[] create(ICreateContext context) {
 		CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
 		ContainerShape container = context.getTargetContainer();
-		CamelModelElement selectedContainer = null;
+		AbstractCamelModelElement selectedContainer = null;
 		if (container instanceof Diagram) {
 			selectedContainer = editor.getModel().getCamelContext();
 		} else {
-			selectedContainer = (CamelModelElement)getBusinessObjectForPictogramElement(container);
+			selectedContainer = (AbstractCamelModelElement)getBusinessObjectForPictogramElement(container);
 		}
 
-		CamelModelElement node = createNode(selectedContainer, selectedContainer != null);
+		AbstractCamelModelElement node = createNode(selectedContainer, selectedContainer != null);
 		if (selectedContainer != null && node != null) {
 			selectedContainer.addChildElement(node);
 			node.setParent(selectedContainer);
@@ -222,7 +223,7 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 	 * 
 	 * @return
 	 */
-	protected CamelModelElement createNode(CamelModelElement parent, boolean createDOMNode) {
+	protected AbstractCamelModelElement createNode(AbstractCamelModelElement parent, boolean createDOMNode) {
 		if( eip != null ) {
 			CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
 			if (editor.getModel() != null) { 
@@ -232,13 +233,13 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
 					final String namespace = parent != null && parent.getXmlNode() != null ? parent.getXmlNode().getPrefix() : null;
 					newNode = editor.getModel().createElement(nodeTypeId, namespace);
 				}
-				return new CamelModelElement(parent, newNode);
+				return new CamelBasicModelElement(parent, newNode);
 			}
 		}
 		if( clazz != null ) {
 			Object o = newInstance(clazz);
-			if( o instanceof CamelModelElement ) {
-				CamelModelElement e = (CamelModelElement)o;
+			if( o instanceof AbstractCamelModelElement ) {
+				AbstractCamelModelElement e = (AbstractCamelModelElement)o;
 				e.setParent(parent);
 				return e;
 			}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/CollapseFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/CollapseFeature.java
@@ -25,7 +25,7 @@ import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.graphiti.services.Graphiti;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -58,8 +58,8 @@ public class CollapseFeature extends AbstractCustomFeature {
 		if (pes != null && pes.length == 1) {
 			Object bo = getBusinessObjectForPictogramElement(pes[0]);
 			// Add more of the objects that collapse here
-			if (bo instanceof CamelModelElement) {
-				return ((CamelModelElement)bo).getChildElements().size() > 0;
+			if (bo instanceof AbstractCamelModelElement) {
+				return ((AbstractCamelModelElement)bo).getChildElements().size() > 0;
 			}
 		}
 		return ret;
@@ -84,7 +84,7 @@ public class CollapseFeature extends AbstractCustomFeature {
 		PictogramElement[] pes = context.getPictogramElements();
 		if (pes != null && pes.length == 1) {
 			Object bo = getBusinessObjectForPictogramElement(pes[0]);
-	 	   	if(bo instanceof CamelModelElement) {
+	 	   	if(bo instanceof AbstractCamelModelElement) {
 	 	   		collapseShape(pes[0]);
 	 	   	}
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DeleteAllEndpointBreakpointsFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DeleteAllEndpointBreakpointsFeature.java
@@ -22,7 +22,7 @@ import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.launcher.debug.model.CamelEndpointBreakpoint;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
@@ -53,7 +53,7 @@ public class DeleteAllEndpointBreakpointsFeature extends DeleteEndpointBreakpoin
     	String projectName = contextFile.getProject().getName();
     	IBreakpoint[] bps = CamelDebugUtils.getBreakpointsForContext(fileName, projectName);
 		for (IBreakpoint bp : bps) {
-			CamelModelElement bo = ((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(((CamelEndpointBreakpoint)bp).getEndpointNodeId());
+			AbstractCamelModelElement bo = ((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(((CamelEndpointBreakpoint)bp).getEndpointNodeId());
 			try {
 				bp.delete();
 			} catch (CoreException ex) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DeleteEndpointBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DeleteEndpointBreakpointFeature.java
@@ -24,7 +24,7 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Shell;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 
 /**
@@ -50,8 +50,8 @@ public class DeleteEndpointBreakpointFeature extends SetEndpointBreakpointFeatur
                 .getStart().getParent() : context.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
         
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement)bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement)bo;
             try {
             	IFile contextFile = getContextFile();
             	String fileName = contextFile.getName();
@@ -110,8 +110,8 @@ public class DeleteEndpointBreakpointFeature extends SetEndpointBreakpointFeatur
                 .getStart().getParent() : cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
         
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement)bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement)bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DisableCamelBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DisableCamelBreakpointFeature.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 
 /**
@@ -51,8 +51,8 @@ public class DisableCamelBreakpointFeature extends SetEndpointBreakpointFeature 
                 .getStart().getParent() : context.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
             try {
             	IFile contextFile = getContextFile();
             	String fileName = contextFile.getName();
@@ -111,8 +111,8 @@ public class DisableCamelBreakpointFeature extends SetEndpointBreakpointFeature 
                 .getStart().getParent() : cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DoubleClickFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DoubleClickFeature.java
@@ -22,7 +22,7 @@ import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.provider.ext.ICustomDblClickHandler;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -71,8 +71,8 @@ public class DoubleClickFeature extends AbstractCustomFeature {
                 .getStart().getParent() : context.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	
         	// inject palette entries delivered via extension points
             IConfigurationElement[] extensions = Platform.getExtensionRegistry().getConfigurationElementsFor(DBL_CLICK_HANDLER_EXT_POINT_ID);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EditConditionalBreakpoint.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EditConditionalBreakpoint.java
@@ -22,7 +22,7 @@ import org.eclipse.jface.window.Window;
 import org.eclipse.swt.widgets.Display;
 import org.fusesource.ide.camel.editor.dialogs.ConditionalBreakpointEditorDialog;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.launcher.debug.model.CamelConditionalBreakpoint;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 
@@ -49,8 +49,8 @@ public class EditConditionalBreakpoint extends SetConditionalBreakpointFeature {
                 .getStart().getParent() : context.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();
@@ -111,8 +111,8 @@ public class EditConditionalBreakpoint extends SetConditionalBreakpointFeature {
                 .getStart().getParent() : cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EnableCamelBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EnableCamelBreakpointFeature.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Shell;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 
 /**
@@ -51,8 +51,8 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
                 .getStart().getParent() : context.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
             try {
             	IFile contextFile = getContextFile();
             	String fileName = contextFile.getName();
@@ -111,8 +111,8 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
                 .getStart().getParent() : cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/GoIntoContainerFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/GoIntoContainerFeature.java
@@ -15,7 +15,7 @@ import org.eclipse.graphiti.features.context.ICustomContext;
 import org.eclipse.graphiti.features.custom.AbstractCustomFeature;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -39,8 +39,8 @@ public class GoIntoContainerFeature extends AbstractCustomFeature {
 		PictogramElement[] pes = context.getPictogramElements();
 		if (pes != null && pes.length == 1) {
 			Object bo = getBusinessObjectForPictogramElement(pes[0]);
-			if (bo instanceof CamelModelElement) {
-				CamelModelElement cme = (CamelModelElement)bo;
+			if (bo instanceof AbstractCamelModelElement) {
+				AbstractCamelModelElement cme = (AbstractCamelModelElement)bo;
 				return 	cme.getNodeTypeId().equals("route") && 
 						cme.equals(CamelUtils.getDiagramEditor().getSelectedContainer()) == false &&
 						cme.getCamelContext().getChildElements().size() > 1;
@@ -57,8 +57,8 @@ public class GoIntoContainerFeature extends AbstractCustomFeature {
 		PictogramElement[] pes = context.getPictogramElements();
 		if (pes != null && pes.length == 1) {
 			Object bo = getBusinessObjectForPictogramElement(pes[0]);
-	 	   	if(bo instanceof CamelModelElement) {
-	 	   		CamelModelElement cme = (CamelModelElement)bo;
+	 	   	if(bo instanceof AbstractCamelModelElement) {
+	 	   		AbstractCamelModelElement cme = (AbstractCamelModelElement)bo;
 	 	   		CamelUtils.getDiagramEditor().setSelectedContainer(cme);
 	 	   	}
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/LayoutDiagramFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/LayoutDiagramFeature.java
@@ -35,7 +35,7 @@ import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.mm.pictograms.Shape;
 import org.eclipse.swt.graphics.Rectangle;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.preferences.PreferenceManager;
 import org.fusesource.ide.preferences.PreferencesConstants;
 
@@ -103,7 +103,7 @@ public class LayoutDiagramFeature extends AbstractCustomFeature {
 				((Connection) cc.getPictogramElements()[0]).getStart().getParent() : 
 				cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
-        return (bo != null && bo instanceof CamelModelElement && ((CamelModelElement)bo).getUnderlyingMetaModelObject().canHaveChildren());
+        return (bo != null && bo instanceof AbstractCamelModelElement && ((AbstractCamelModelElement)bo).getUnderlyingMetaModelObject().canHaveChildren());
 	}
 	
 	/*

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetConditionalBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetConditionalBreakpointFeature.java
@@ -31,7 +31,7 @@ import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.dialogs.ConditionalBreakpointEditorDialog;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 import org.fusesource.ide.launcher.debug.util.ICamelDebugConstants;
@@ -60,8 +60,8 @@ public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeatur
         final Object bo = getBusinessObjectForPictogramElement(_pe);
         final IResource resource = getResource();
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
             try {
             	Boolean userWantsUpdate = null;
             	IFile contextFile = getContextFile();
@@ -163,8 +163,8 @@ public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeatur
                 .getStart().getParent() : cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetEndpointBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetEndpointBreakpointFeature.java
@@ -32,7 +32,7 @@ import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 import org.fusesource.ide.launcher.debug.util.ICamelDebugConstants;
@@ -61,8 +61,8 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
         final Object bo = getBusinessObjectForPictogramElement(_pe);
         final IResource resource = getResource();
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
             try {
             	Boolean userWantsUpdate = null;
             	IFile contextFile = getContextFile();
@@ -153,8 +153,8 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
                 .getStart().getParent() : cc.getPictogramElements()[0];
         final Object bo = getBusinessObjectForPictogramElement(_pe);
        
-        if (bo instanceof CamelModelElement) {
-        	CamelModelElement _ep = (CamelModelElement) bo;
+        if (bo instanceof AbstractCamelModelElement) {
+        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
         	IFile contextFile = getContextFile();
         	String fileName = contextFile.getName();
         	String projectName = contextFile.getProject().getName();
@@ -194,7 +194,7 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	 * @param node
 	 * @return
 	 */
-	protected boolean askForIDUpdate(CamelModelElement node) {
+	protected boolean askForIDUpdate(AbstractCamelModelElement node) {
 		final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
         final Shell shell;
         if (container instanceof CamelDesignEditor) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/delete/DeleteFigureFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/delete/DeleteFigureFeature.java
@@ -16,7 +16,7 @@ import org.fusesource.ide.camel.editor.commands.DiagramOperations;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -40,8 +40,8 @@ public class DeleteFigureFeature extends DefaultDeleteFeature {
 		if (bo != null ) {
 			if (bo instanceof CamelElementConnection) {
 				deleteFlowFromModel((CamelElementConnection) bo);
-			} else if (bo instanceof CamelModelElement) {
-				deleteBOFromModel((CamelModelElement)bo);
+			} else if (bo instanceof AbstractCamelModelElement) {
+				deleteBOFromModel((AbstractCamelModelElement)bo);
 			} else {
 				CamelEditorUIActivator.pluginLog().logWarning("Cannot figure out Node or Flow from BO: " + bo);
 			}
@@ -50,7 +50,7 @@ public class DeleteFigureFeature extends DefaultDeleteFeature {
 		DiagramOperations.layoutDiagram(CamelUtils.getDiagramEditor());
 	}
 
-	private void deleteBOFromModel(CamelModelElement nodeToRemove) {
+	private void deleteBOFromModel(AbstractCamelModelElement nodeToRemove) {
 		// lets remove all connections
 		if (nodeToRemove.getParent() != null) nodeToRemove.getParent().removeChildElement(nodeToRemove);
 		if (nodeToRemove.getInputElement() != null) nodeToRemove.getInputElement().setOutputElement(null);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/delete/RemoveFigureFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/delete/RemoveFigureFeature.java
@@ -19,7 +19,7 @@ import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -47,8 +47,8 @@ public class RemoveFigureFeature extends DefaultRemoveFeature {
 			Object bo = businessObjectsForPictogramElement[0];
 			if (bo instanceof CamelElementConnection) {
 				deleteFlowFromModel((CamelElementConnection) bo);
-			} else if (bo instanceof CamelModelElement) {
-				deleteBOFromModel((CamelModelElement)bo);
+			} else if (bo instanceof AbstractCamelModelElement) {
+				deleteBOFromModel((AbstractCamelModelElement)bo);
 			} else {
 				CamelEditorUIActivator.pluginLog().logWarning("Cannot figure out Node or Flow from BO: " + bo);
 			}
@@ -64,7 +64,7 @@ public class RemoveFigureFeature extends DefaultRemoveFeature {
 		DiagramOperations.layoutDiagram(CamelUtils.getDiagramEditor());
 	}
 
-	private void deleteBOFromModel(CamelModelElement nodeToRemove) {
+	private void deleteBOFromModel(AbstractCamelModelElement nodeToRemove) {
 		// we can't remove null objects or the root of the routes
 		if (nodeToRemove == null || nodeToRemove instanceof CamelContextElement) return;
 

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/DirectEditNodeFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/DirectEditNodeFeature.java
@@ -19,7 +19,7 @@ import org.eclipse.graphiti.mm.algorithms.GraphicsAlgorithm;
 import org.eclipse.graphiti.mm.algorithms.Text;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.mm.pictograms.Shape;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 
 public class DirectEditNodeFeature extends AbstractDirectEditingFeature {
@@ -41,7 +41,7 @@ public class DirectEditNodeFeature extends AbstractDirectEditingFeature {
 		GraphicsAlgorithm ga = context.getGraphicsAlgorithm();
 		// support direct editing, if it is a EClass, and the user clicked
 		// directly on the text and not somewhere else in the rectangle
-		if (bo instanceof CamelModelElement && ga instanceof Text) {
+		if (bo instanceof AbstractCamelModelElement && ga instanceof Text) {
 			// EClass eClass = (EClass) bo;
 			// additionally the flag isFrozen must be false
 			// return !eClass.isFrozen();
@@ -55,7 +55,7 @@ public class DirectEditNodeFeature extends AbstractDirectEditingFeature {
 		// return the current name of the EClass
 		PictogramElement pe = context.getPictogramElement();
 		//EClass eClass = (EClass) getBusinessObjectForPictogramElement(pe);
-		CamelModelElement node = (CamelModelElement)getBusinessObjectForPictogramElement(pe);
+		AbstractCamelModelElement node = (AbstractCamelModelElement)getBusinessObjectForPictogramElement(pe);
 		//return eClass.getName();
 		return node.getDisplayText();
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/LayoutNodeFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/LayoutNodeFeature.java
@@ -25,7 +25,7 @@ import org.eclipse.graphiti.services.IGaService;
 import org.eclipse.swt.graphics.Rectangle;
 import org.fusesource.ide.camel.editor.utils.FigureUIFactory;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 
 public class LayoutNodeFeature extends AbstractLayoutFeature {
@@ -51,7 +51,7 @@ public class LayoutNodeFeature extends AbstractLayoutFeature {
 		Object[] bos = getAllBusinessObjectsForPictogramElement(pe);
 		
 		return bos != null && bos.length == 1
-	              && bos[0] instanceof CamelModelElement;
+	              && bos[0] instanceof AbstractCamelModelElement;
 	}
 
 	/*
@@ -68,12 +68,12 @@ public class LayoutNodeFeature extends AbstractLayoutFeature {
 		Rectangle maxDim = new Rectangle(containerGa.getX(), containerGa.getY(), containerGa.getWidth(), containerGa.getHeight());
 		
 		ArrayList<PictogramElement> containers = new ArrayList<PictogramElement>();		
-		NodeUtils.getAllContainers(getFeatureProvider(), (CamelModelElement)bo, containers);
+		NodeUtils.getAllContainers(getFeatureProvider(), (AbstractCamelModelElement)bo, containers);
 		containers.add(containerShape);
 		for (PictogramElement pe : containers) {
 			Object peBO = getBusinessObjectForPictogramElement(pe);
-			if (peBO instanceof CamelModelElement) {
-				CamelModelElement container = (CamelModelElement)peBO;
+			if (peBO instanceof AbstractCamelModelElement) {
+				AbstractCamelModelElement container = (AbstractCamelModelElement)peBO;
 				IDimension dPe = gaService.calculateSize(pe.getGraphicsAlgorithm(), true);
 				if (dPe.getWidth() + pe.getGraphicsAlgorithm().getX() > maxDim.width) maxDim.width = dPe.getWidth() + pe.getGraphicsAlgorithm().getX();
 				if (dPe.getHeight() + pe.getGraphicsAlgorithm().getY() > maxDim.height) maxDim.height = dPe.getHeight() + pe.getGraphicsAlgorithm().getY();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/ReconnectNodesFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/ReconnectNodesFeature.java
@@ -15,7 +15,7 @@ import org.eclipse.graphiti.features.context.IReconnectionContext;
 import org.eclipse.graphiti.features.impl.DefaultReconnectionFeature;
 import org.eclipse.graphiti.mm.pictograms.Anchor;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -33,12 +33,12 @@ public class ReconnectNodesFeature extends DefaultReconnectionFeature {
 	/**
 	 * Returns the EClass belonging to the anchor, or null if not available.
 	 */
-	private CamelModelElement getNode(Anchor anchor) {
+	private AbstractCamelModelElement getNode(Anchor anchor) {
 		if (anchor != null) {
 			Object obj = getBusinessObjectForPictogramElement(anchor
 					.getParent());
-			if (obj instanceof CamelModelElement) {
-				return (CamelModelElement) obj;
+			if (obj instanceof AbstractCamelModelElement) {
+				return (AbstractCamelModelElement) obj;
 			}
 		}
 		return null;
@@ -53,9 +53,9 @@ public class ReconnectNodesFeature extends DefaultReconnectionFeature {
 		super.postReconnect(context);
 		
 		// delete the old connection / add the new connection
-		CamelModelElement source = getNode(context.getConnection().getStart());
-		CamelModelElement oldTarget = getNode(context.getOldAnchor());
-		CamelModelElement newTarget = getNode(context.getNewAnchor());
+		AbstractCamelModelElement source = getNode(context.getConnection().getStart());
+		AbstractCamelModelElement oldTarget = getNode(context.getOldAnchor());
+		AbstractCamelModelElement newTarget = getNode(context.getNewAnchor());
 		
 		if (source.getOutputElement().equals(oldTarget)) {
 			source.setOutputElement(null);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/ResizeNodeFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/ResizeNodeFeature.java
@@ -21,7 +21,7 @@ import org.eclipse.graphiti.services.Graphiti;
 import org.fusesource.ide.camel.editor.features.custom.CollapseFeature;
 import org.fusesource.ide.camel.editor.utils.DiagramUtils;
 import org.fusesource.ide.camel.editor.utils.FigureUIFactory;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -42,8 +42,8 @@ public class ResizeNodeFeature extends DefaultResizeShapeFeature {
 	@Override
 	public boolean canResizeShape(IResizeShapeContext context) {
 		Object bo = getBusinessObjectForPictogramElement(context.getPictogramElement());
-		if (bo != null && bo instanceof CamelModelElement) {
-			CamelModelElement cme = (CamelModelElement)bo;
+		if (bo != null && bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement cme = (AbstractCamelModelElement)bo;
 			if (cme.getUnderlyingMetaModelObject().canHaveChildren()) return true;
 		}
 		return false;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/UpdateNodeFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/misc/UpdateNodeFeature.java
@@ -22,7 +22,7 @@ import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -38,7 +38,7 @@ public class UpdateNodeFeature extends AbstractUpdateFeature {
 	public boolean canUpdate(IUpdateContext context) {
 		// return true, if linked business object is an EClass
 		Object bo = getBusinessObjectForPictogramElement(context.getPictogramElement());
-		return (bo instanceof CamelModelElement);
+		return (bo instanceof AbstractCamelModelElement);
 	}
 
 	public IReason updateNeeded(IUpdateContext context) {
@@ -59,11 +59,11 @@ public class UpdateNodeFeature extends AbstractUpdateFeature {
 		// retrieve name from business model
 		String businessName = null;
 		Object bo = getBusinessObjectForPictogramElement(pictogramElement);
-		if (bo instanceof CamelModelElement) {
-			CamelModelElement eClass = (CamelModelElement) bo;
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement eClass = (AbstractCamelModelElement) bo;
 			// do check if underlying xml node changed / document changed
 			CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
-			CamelModelElement bo2 = editor.getModel().findNode(eClass.getId());
+			AbstractCamelModelElement bo2 = editor.getModel().findNode(eClass.getId());
 			if (bo2 != null && bo2.getXmlNode().isEqualNode(eClass.getXmlNode()) == false) {
 				return Reason.createTrueReason("The Model has been changed. Please update the figure."); //$NON-NLS-1$
 			}
@@ -91,12 +91,12 @@ public class UpdateNodeFeature extends AbstractUpdateFeature {
 		String businessName = null;
 		PictogramElement pictogramElement = context.getPictogramElement();
 		Object bo = getBusinessObjectForPictogramElement(pictogramElement);
-		if (bo instanceof CamelModelElement) {
-			CamelModelElement eClass = (CamelModelElement) bo;
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement eClass = (AbstractCamelModelElement) bo;
 		
 			// do check if underlying xml node changed / document changed
 			CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
-			CamelModelElement bo2 = editor.getModel().findNode(eClass.getId());
+			AbstractCamelModelElement bo2 = editor.getModel().findNode(eClass.getId());
 			if (bo2 != null && bo2.getXmlNode().isEqualNode(eClass.getXmlNode()) == false) {
 				link(pictogramElement, bo2);
 				this.changed = true;
@@ -120,12 +120,12 @@ public class UpdateNodeFeature extends AbstractUpdateFeature {
 					this.changed = true;
 				} else if (shape instanceof Image) {
 					// update the icon image
-					CamelModelElement addedClass = (CamelModelElement)bo;
+					AbstractCamelModelElement addedClass = (AbstractCamelModelElement)bo;
 					String iconKey = null;
 					// set the new icon id - refresh will to the rest
-					if (((CamelModelElement)bo).isEndpointElement()) {
+					if (((AbstractCamelModelElement)bo).isEndpointElement()) {
 						iconKey = ImageProvider.getKeyForLargeIcon(addedClass.getIconName());
-					} else if (((CamelModelElement)bo).getUnderlyingMetaModelObject().canHaveChildren()) {
+					} else if (((AbstractCamelModelElement)bo).getUnderlyingMetaModelObject().canHaveChildren()) {
 						iconKey = ImageProvider.getKeyForSmallIcon(addedClass.getIconName());
 					} else {
 						iconKey = ImageProvider.getKeyForLargeIcon(addedClass.getIconName());

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelDiagramLoader.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelDiagramLoader.java
@@ -27,7 +27,7 @@ import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.features.create.CreateFlowFeature;
 import org.fusesource.ide.camel.editor.utils.FigureUIFactory;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.preferences.PreferenceManager;
 import org.fusesource.ide.preferences.PreferencesConstants;
@@ -60,16 +60,16 @@ public class CamelDiagramLoader {
 	 * 
 	 * @param container
 	 */
-	public void loadModel(CamelModelElement container) {
+	public void loadModel(AbstractCamelModelElement container) {
 		if (container == null) {
 			return;
 		}
-		List<CamelModelElement> processedNodes = new ArrayList<CamelModelElement>();
-		List<CamelModelElement> children = container instanceof CamelRouteElement ? Arrays.asList(container) : container.getChildElements();
+		List<AbstractCamelModelElement> processedNodes = new ArrayList<AbstractCamelModelElement>();
+		List<AbstractCamelModelElement> children = container instanceof CamelRouteElement ? Arrays.asList(container) : container.getChildElements();
 		int x = 40;
 		int y = 40;
-		CamelModelElement lastElem = container;
-		for (CamelModelElement node : children) {
+		AbstractCamelModelElement lastElem = container;
+		for (AbstractCamelModelElement node : children) {
 			int res = addProcessor(lastElem, node, x, y, processedNodes, diagram);
 			if (this.orientation == PositionConstants.EAST) {
 				x = res;	
@@ -80,7 +80,7 @@ public class CamelDiagramLoader {
 		}
 	}
 
-	private int addProcessor(CamelModelElement lastElement, CamelModelElement node, int x, int y, List<CamelModelElement> processedNodes, ContainerShape container) {
+	private int addProcessor(AbstractCamelModelElement lastElement, AbstractCamelModelElement node, int x, int y, List<AbstractCamelModelElement> processedNodes, ContainerShape container) {
 		// Create the context information
 		AddContext addContext = new AddContext();
 		addContext.setNewObject(node);
@@ -130,8 +130,8 @@ public class CamelDiagramLoader {
 
 			if (node.getChildElements().size() > 0) {
 				int subX = 40, subY = 40;
-				CamelModelElement lastSub = null;
-				for (CamelModelElement subNode : node.getChildElements()) {
+				AbstractCamelModelElement lastSub = null;
+				for (AbstractCamelModelElement subNode : node.getChildElements()) {
 					int res = addProcessor(lastSub, subNode, subX, subY, processedNodes, getContainerShape(destState));
 					if (this.orientation == PositionConstants.EAST) {
 						subX = res;	

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelModelChangeListener.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelModelChangeListener.java
@@ -29,7 +29,7 @@ import org.eclipse.graphiti.platform.IDiagramBehavior;
 import org.eclipse.graphiti.platform.IDiagramContainer;
 import org.eclipse.swt.widgets.Display;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelModelNotificationService.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelModelNotificationService.java
@@ -17,7 +17,7 @@ import org.eclipse.graphiti.dt.IDiagramTypeProvider;
 import org.eclipse.graphiti.features.context.impl.UpdateContext;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -52,9 +52,9 @@ public class CamelModelNotificationService extends DefaultNotificationService {
 			if (picElem != null) {
 				Object obo = getDiagramTypeProvider().getFeatureProvider().getBusinessObjectForPictogramElement(picElem);
 				if (obo != null) {
-					CamelModelElement bo1 = (CamelModelElement)obo;
+					AbstractCamelModelElement bo1 = (AbstractCamelModelElement)obo;
 					CamelDesignEditor editor = (CamelDesignEditor)getDiagramTypeProvider().getDiagramBehavior().getDiagramContainer();
-					CamelModelElement bo2 = editor.getModel().findNode(bo1.getId());
+					AbstractCamelModelElement bo2 = editor.getModel().findNode(bo1.getId());
 					if (bo2 != null && bo2.getXmlNode().isEqualNode(bo1.getXmlNode()) == false) {
 						relatedBOs.add(picElem);
 					}					

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavContentProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavContentProvider.java
@@ -29,7 +29,7 @@ import org.eclipse.ui.navigator.ICommonContentExtensionSite;
 import org.eclipse.ui.navigator.ICommonContentProvider;
 import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 
 /**
@@ -72,7 +72,7 @@ public class CamelCtxNavContentProvider implements ICommonContentProvider {
 		final CamelFile rc = ioHandler.loadCamelModel(camelFile, new NullProgressMonitor());
 		if (rc != null && rc.getCamelContext() != null) {
 			List<CamelCtxNavRouteNode> routes = new ArrayList<CamelCtxNavRouteNode>();
-			for(CamelModelElement node : rc.getCamelContext().getChildElements()) {
+			for(AbstractCamelModelElement node : rc.getCamelContext().getChildElements()) {
 				if(node instanceof CamelRouteElement) {
 					routes.add(new CamelCtxNavRouteNode((CamelRouteElement)node, camelFile));
 				}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavLabelProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavLabelProvider.java
@@ -13,7 +13,7 @@ package org.fusesource.ide.camel.editor.navigator;
 import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.swt.graphics.Image;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author Renjith M. 
@@ -26,8 +26,8 @@ public class CamelCtxNavLabelProvider extends LabelProvider {
 	 */
 	@Override
 	public Image getImage(Object element) {
-		if( element instanceof CamelModelElement) {
-			return CamelEditorUIActivator.getDefault().getImage(((CamelModelElement)element).getIconName().replaceAll(".png", "16.png"));
+		if( element instanceof AbstractCamelModelElement) {
+			return CamelEditorUIActivator.getDefault().getImage(((AbstractCamelModelElement)element).getIconName().replaceAll(".png", "16.png"));
 		} else if (element instanceof CamelCtxNavRouteNode) {
 			return CamelEditorUIActivator.getDefault().getImage(((CamelCtxNavRouteNode) element).getCamelRoute().getIconName().replaceAll(".png", "16.png"));
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavRouteNode.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/navigator/CamelCtxNavRouteNode.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 import org.eclipse.core.resources.IFile;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 
 /**
@@ -55,9 +55,9 @@ public class CamelCtxNavRouteNode  {
 		return this.mRouteSupport.toString();
 	}
 	
-	private static List<String> getChildNodesDisplayText(CamelModelElement routeSupport) {
+	private static List<String> getChildNodesDisplayText(AbstractCamelModelElement routeSupport) {
 		List<String> nodeKeys = new ArrayList<String>();
-		for (CamelModelElement childNode : routeSupport.getChildElements()) {
+		for (AbstractCamelModelElement childNode : routeSupport.getChildElements()) {
 			nodeKeys.add(childNode.getDisplayText());
 		}
 		return nodeKeys;
@@ -76,9 +76,9 @@ public class CamelCtxNavRouteNode  {
 			List<String> nodeKeys = getChildNodesDisplayText(this.mRouteSupport);
 			String nodeDisplayText = this.mRouteSupport.getDisplayText();
 			if(nodeDisplayText!=null){
-				for(CamelModelElement node : model.getChildElements()) {
+				for(AbstractCamelModelElement node : model.getChildElements()) {
 					if(node instanceof CamelRouteElement && nodeDisplayText.equals(node.getDisplayText())) {
-						List<CamelModelElement> editorNodeChildren = node.getChildElements();
+						List<AbstractCamelModelElement> editorNodeChildren = node.getChildElements();
 						if(nodeKeys.size() == editorNodeChildren.size()) {	
 							List<String> editorNodeKeys = getChildNodesDisplayText(node);
 							if(editorNodeKeys.containsAll(nodeKeys)) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/outline/CamelModelOutlineContentProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/outline/CamelModelOutlineContentProvider.java
@@ -12,7 +12,7 @@ package org.fusesource.ide.camel.editor.outline;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.Viewer;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -48,10 +48,10 @@ public class CamelModelOutlineContentProvider implements ITreeContentProvider {
 	 */
 	@Override
 	public Object[] getChildren(Object parentElement) {
-		if (parentElement instanceof CamelModelElement[]) {
-			return (CamelModelElement[])parentElement;
-		} else if (parentElement instanceof CamelModelElement) {
-			CamelModelElement e = (CamelModelElement)parentElement;
+		if (parentElement instanceof AbstractCamelModelElement[]) {
+			return (AbstractCamelModelElement[])parentElement;
+		} else if (parentElement instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement e = (AbstractCamelModelElement)parentElement;
 			return e.getChildElements().toArray();
 		}
 		return EMPTY_ARRAY;
@@ -70,8 +70,8 @@ public class CamelModelOutlineContentProvider implements ITreeContentProvider {
 	 */
 	@Override
 	public boolean hasChildren(Object element) {
-		if (element instanceof CamelModelElement) {
-			CamelModelElement e = (CamelModelElement)element;
+		if (element instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement e = (AbstractCamelModelElement)element;
 			return e.getChildElements().size()>0;
 		}
 		return false;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/outline/CamelModelOutlineLabelProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/outline/CamelModelOutlineLabelProvider.java
@@ -15,7 +15,7 @@ import org.eclipse.jface.viewers.LabelProvider;
 import org.eclipse.jface.viewers.StyledString;
 import org.eclipse.swt.graphics.Image;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -33,8 +33,8 @@ public class CamelModelOutlineLabelProvider extends LabelProvider implements ISt
 	 */
 	@Override
 	public Image getImage(Object element) {
-		if (element instanceof CamelModelElement) {
-			CamelModelElement cme = (CamelModelElement)element;
+		if (element instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement cme = (AbstractCamelModelElement)element;
 			Image icon = CamelEditorUIActivator.getDefault().getImage(cme.getIconName().replaceAll(".png", "16.png"));
 			if (icon == null) {
 				icon = CamelEditorUIActivator.getDefault().getImage("endpoint16.png");
@@ -49,8 +49,8 @@ public class CamelModelOutlineLabelProvider extends LabelProvider implements ISt
 	 */
 	@Override
 	public String getText(Object element) {
-		if (element instanceof CamelModelElement) {
-			CamelModelElement cme = (CamelModelElement)element;
+		if (element instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement cme = (AbstractCamelModelElement)element;
 			return cme.getDisplayText();
 		}
 		return null;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/outline/CamelModelOutlinePage.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/outline/CamelModelOutlinePage.java
@@ -18,7 +18,7 @@ import org.eclipse.ui.views.contentoutline.ContentOutlinePage;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.ICamelModelListener;
 
 /**
@@ -57,7 +57,7 @@ public class CamelModelOutlinePage extends ContentOutlinePage implements ICamelM
 		viewer.setContentProvider(new CamelModelOutlineContentProvider());
 		viewer.setLabelProvider(new CamelModelOutlineLabelProvider());
 		viewer.addSelectionChangedListener(this);
-		CamelModelElement selectedContainer = this.designEditor.getSelectedContainer();
+		AbstractCamelModelElement selectedContainer = this.designEditor.getSelectedContainer();
 		if (selectedContainer == null) selectedContainer = this.designEditor.getModel().getCamelContext();
 		viewer.setInput(getModelRoots(selectedContainer));
 		viewer.expandAll();
@@ -68,7 +68,7 @@ public class CamelModelOutlinePage extends ContentOutlinePage implements ICamelM
 	 * 
 	 * @param cme
 	 */
-	public void setOutlineSelection(CamelModelElement cme) {
+	public void setOutlineSelection(AbstractCamelModelElement cme) {
 		if (cme == null || cme.getId() == null || getTreeViewer() == null || getTreeViewer().getTree().isDisposed()) return;
 		if (getTreeViewer() != null) getTreeViewer().setSelection(new StructuredSelection(cme), true);
 		if (getTreeViewer() != null && getTreeViewer().getSelection().isEmpty()) {
@@ -80,13 +80,13 @@ public class CamelModelOutlinePage extends ContentOutlinePage implements ICamelM
 		}
 	}
 
-	private TreeItem findTreeItemForElement(CamelModelElement cme, TreeItem[] treeItems) {
+	private TreeItem findTreeItemForElement(AbstractCamelModelElement cme, TreeItem[] treeItems) {
 		TreeItem tRes = null;
 		for (TreeItem ti : treeItems) {
 			if (tRes != null) break;
 			Object o = ti.getData();
-			if (o instanceof CamelModelElement) {
-				CamelModelElement cme2 = (CamelModelElement)o;
+			if (o instanceof AbstractCamelModelElement) {
+				AbstractCamelModelElement cme2 = (AbstractCamelModelElement)o;
 				if (cme.getId().equals(cme2.getId())) {
 					tRes = ti;
 					break;
@@ -114,21 +114,21 @@ public class CamelModelOutlinePage extends ContentOutlinePage implements ICamelM
 	 * 
 	 * @param container
 	 */
-	public void changeInput(CamelModelElement container) {
+	public void changeInput(AbstractCamelModelElement container) {
 		if (getTreeViewer() != null && getTreeViewer().getTree().isDisposed() == false) {
 			getTreeViewer().setInput(getModelRoots(container));
 			modelChanged();
 		}
 	}
 	
-	private CamelModelElement[] getModelRoots(CamelModelElement selectedContainer) {
-		CamelModelElement[] container = null;
+	private AbstractCamelModelElement[] getModelRoots(AbstractCamelModelElement selectedContainer) {
+		AbstractCamelModelElement[] container = null;
 		if (selectedContainer instanceof CamelFile) {
-			container = selectedContainer.getChildElements().get(0).getChildElements().toArray(new CamelModelElement[selectedContainer.getChildElements().size()]);
+			container = selectedContainer.getChildElements().get(0).getChildElements().toArray(new AbstractCamelModelElement[selectedContainer.getChildElements().size()]);
 		} else if (selectedContainer instanceof CamelContextElement) {
-			container = selectedContainer.getChildElements().toArray(new CamelModelElement[selectedContainer.getChildElements().size()]);
+			container = selectedContainer.getChildElements().toArray(new AbstractCamelModelElement[selectedContainer.getChildElements().size()]);
 		} else {
-			container = new CamelModelElement[] { selectedContainer };
+			container = new AbstractCamelModelElement[] { selectedContainer };
 		}
 		return container;
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/AdvancedPropertiesFilter.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/AdvancedPropertiesFilter.java
@@ -13,7 +13,7 @@ package org.fusesource.ide.camel.editor.properties;
 import org.eclipse.graphiti.ui.internal.parts.ContainerShapeEditPart;
 import org.eclipse.jface.viewers.IFilter;
 import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 
 /**
@@ -26,7 +26,7 @@ public class AdvancedPropertiesFilter implements IFilter {
      */
     @Override
     public boolean select(Object toTest) {
-        CamelModelElement ep = getSelectedEndpoint(toTest);
+        AbstractCamelModelElement ep = getSelectedEndpoint(toTest);
         if (ep != null && (ep.getNodeTypeId().equalsIgnoreCase("from") || ep.getNodeTypeId().equalsIgnoreCase("to"))) {
             if (ep.getParameter("uri") == null || ((String)ep.getParameter("uri")).trim().length()<1) return false;
         	int protocolSeparatorIdx = ((String)ep.getParameter("uri")).indexOf(":");
@@ -39,13 +39,13 @@ public class AdvancedPropertiesFilter implements IFilter {
         return false;
     }
     
-    protected CamelModelElement getSelectedEndpoint(Object toTest) {
+    protected AbstractCamelModelElement getSelectedEndpoint(Object toTest) {
         Object bo = null;
         if (toTest instanceof ContainerShapeEditPart) {
             bo = ((ContainerShapeEditPart)toTest).getFeatureProvider().getBusinessObjectForPictogramElement(((ContainerShapeEditPart)toTest).getPictogramElement());
         }
-        if (bo instanceof CamelModelElement) {
-            return (CamelModelElement)bo;
+        if (bo instanceof AbstractCamelModelElement) {
+            return (AbstractCamelModelElement)bo;
         }
         return null;
     }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/CamelTypeMapper.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/CamelTypeMapper.java
@@ -12,7 +12,7 @@ package org.fusesource.ide.camel.editor.properties;
 
 import org.eclipse.ui.views.properties.tabbed.ITypeMapper;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -23,11 +23,19 @@ public class CamelTypeMapper implements ITypeMapper {
 	 * @see org.eclipse.ui.views.properties.tabbed.ITypeMapper#mapType(java.lang.Object)
 	 */
 	@Override
-	public Class mapType(Object object) {
-		CamelModelElement node = NodeUtils.toCamelElement(object);
+	public Class<?> mapType(Object object) {
+		AbstractCamelModelElement node = resolveCamelModelElement(object);
 		if (node != null) {
-			return CamelModelElement.class;
+			return node.getClass();
 		}
 		return object.getClass();
+	}
+
+	/**
+	 * @param object
+	 * @return
+	 */
+	protected AbstractCamelModelElement resolveCamelModelElement(Object object) {
+		return NodeUtils.toCamelElement(object);
 	}
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/DetailsSection.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/DetailsSection.java
@@ -68,7 +68,7 @@ import org.eclipse.ui.PlatformUI;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.util.CamelComponentUtils;
 import org.fusesource.ide.camel.model.service.core.util.PropertiesUtils;
 import org.fusesource.ide.camel.validation.model.NumberValidator;
@@ -238,7 +238,7 @@ public class DetailsSection extends FusePropertySection {
 										return ValidationStatus.error("One of Ref and Uri values have to be filled!");
 									} else {
 										// ref found - now check if REF has URI defined
-										CamelModelElement cme = selectedEP.getCamelContext().findNode((String)selectedEP.getParameter("ref"));
+										AbstractCamelModelElement cme = selectedEP.getCamelContext().findNode((String)selectedEP.getParameter("ref"));
 										if (cme == null || cme.getParameter("uri") == null || ((String)cme.getParameter("uri")).trim().length()<1) {
 											// no uri defined on ref
 											return ValidationStatus.error("The referenced endpoint has no URI defined or does not exist.");
@@ -265,7 +265,7 @@ public class DetailsSection extends FusePropertySection {
 
 								if (value != null && value instanceof String && value.toString().trim().length()>0) {
 									String refId = (String)value;
-									CamelModelElement cme = selectedEP.getCamelContext().findNode(refId);
+									AbstractCamelModelElement cme = selectedEP.getCamelContext().findNode(refId);
 									if (cme == null) {
 										// check for global beans
 										if (selectedEP.getCamelFile().getGlobalDefinitions().containsKey(refId) == false) {
@@ -547,7 +547,7 @@ public class DetailsSection extends FusePropertySection {
                 choiceCombo.setEditable(false);
 				choiceCombo.setLayoutData(createPropertyFieldLayoutData());
                 
-                final CamelModelElement expressionElement = this.selectedEP.getParameter(prop.getName()) != null ? (CamelModelElement)this.selectedEP.getParameter(prop.getName()) : null;
+                final AbstractCamelModelElement expressionElement = this.selectedEP.getParameter(prop.getName()) != null ? (AbstractCamelModelElement)this.selectedEP.getParameter(prop.getName()) : null;
                 choiceCombo.setItems(CamelComponentUtils.getOneOfList(prop));
 
                 final Composite eform = getWidgetFactory().createFlatFormComposite(page);
@@ -562,14 +562,14 @@ public class DetailsSection extends FusePropertySection {
                     public void widgetSelected(SelectionEvent e) {
                         CCombo choice = (CCombo)e.getSource();
                         String language = choice.getText();
-                        languageChanged(language, eform, selectedEP.getParameter(prop.getName()) != null ? (CamelModelElement)selectedEP.getParameter(prop.getName()) : null, page, prop);
+                        languageChanged(language, eform, selectedEP.getParameter(prop.getName()) != null ? (AbstractCamelModelElement)selectedEP.getParameter(prop.getName()) : null, page, prop);
                     }
                 });
                 
 				if (expressionElement != null) {
 					String value = expressionElement.getNodeTypeId();
-					if (expressionElement.getParameter("expression") != null && expressionElement.getParameter("expression") instanceof CamelModelElement ) {
-						CamelModelElement ex = (CamelModelElement)expressionElement.getParameter("expression");
+					if (expressionElement.getParameter("expression") != null && expressionElement.getParameter("expression") instanceof AbstractCamelModelElement ) {
+						AbstractCamelModelElement ex = (AbstractCamelModelElement)expressionElement.getParameter("expression");
 	                    value = ex.getTranslatedNodeName();
 					}
                     choiceCombo.deselectAll();
@@ -610,7 +610,7 @@ public class DetailsSection extends FusePropertySection {
                 choiceCombo.setEditable(false);
 				choiceCombo.setLayoutData(createPropertyFieldLayoutData());
                 
-                final CamelModelElement dataformatElement = this.selectedEP.getParameter(prop.getName()) != null ? (CamelModelElement)this.selectedEP.getParameter(prop.getName()) : null;
+                final AbstractCamelModelElement dataformatElement = this.selectedEP.getParameter(prop.getName()) != null ? (AbstractCamelModelElement)this.selectedEP.getParameter(prop.getName()) : null;
                 choiceCombo.setItems(CamelComponentUtils.getOneOfList(prop));
 
                 final Composite eform = getWidgetFactory().createFlatFormComposite(page);
@@ -625,7 +625,7 @@ public class DetailsSection extends FusePropertySection {
                     public void widgetSelected(SelectionEvent e) {
                         CCombo choice = (CCombo)e.getSource();
                         String dataformat = choice.getText();
-                        dataFormatChanged(dataformat, eform, selectedEP.getParameter(prop.getName()) != null ? (CamelModelElement)selectedEP.getParameter(prop.getName()) : null, page, prop);
+                        dataFormatChanged(dataformat, eform, selectedEP.getParameter(prop.getName()) != null ? (AbstractCamelModelElement)selectedEP.getParameter(prop.getName()) : null, page, prop);
                     }
                 });
                 

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/DocumentationSection.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/DocumentationSection.java
@@ -37,7 +37,7 @@ import org.eclipse.ui.help.IWorkbenchHelpSystem;
 import org.eclipse.ui.views.properties.tabbed.TabbedPropertySheetPage;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.internal.UIMessages;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * Shows the documentation for the currently selected node
@@ -71,7 +71,7 @@ public class DocumentationSection extends NodeSectionSupport {
 	 * onNodeChanged(org.fusesource.ide.camel.model.AbstractNode)
 	 */
 	@Override
-	protected void onNodeChanged(CamelModelElement node) {
+	protected void onNodeChanged(AbstractCamelModelElement node) {
 		this.node = node;
 		form.setText(node != null ? String.format("%s - %s", UIMessages.propertiesDocumentationTitle, node.getNodeTypeId()) : UIMessages.propertiesDocumentationTitle);
 		showDocumentationPage();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/NodeSectionSupport.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/NodeSectionSupport.java
@@ -20,18 +20,18 @@ import org.eclipse.ui.views.properties.tabbed.AbstractPropertySection;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.editor.utils.NodeSelectionSupport;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
  */
 public abstract class NodeSectionSupport extends AbstractPropertySection {
-	protected CamelModelElement node;
+	protected AbstractCamelModelElement node;
 	private WorkbenchPart lastPart;
 
 	private NodeSelectionSupport nodeListener = new NodeSelectionSupport() {
 		@Override
-		protected void onNodeChanged(CamelModelElement node) {
+		protected void onNodeChanged(AbstractCamelModelElement node) {
 			super.onNodeChanged(node);
 			setSelectedNode(node);
 		}
@@ -75,14 +75,14 @@ public abstract class NodeSectionSupport extends AbstractPropertySection {
 		// + selection.getClass());
 		super.setInput(part, selection);
 
-		CamelModelElement newNode = getSelectedNode(selection);
+		AbstractCamelModelElement newNode = getSelectedNode(selection);
 
 		// Activator.getLogger().debug("Selection first element is " + input +
 		// " of type: " + (input == null ? null : input.getClass()));
 		setSelectedNode(newNode);
 	}
 
-	protected CamelModelElement getSelectedNode(ISelection selection) {
+	protected AbstractCamelModelElement getSelectedNode(ISelection selection) {
 		return NodeUtils.getSelectedNode(selection);
 	}
 
@@ -92,7 +92,7 @@ public abstract class NodeSectionSupport extends AbstractPropertySection {
 
 		// lets update the node to the current selection
 		ISelection selection = null;
-		CamelModelElement newNode = null;
+		AbstractCamelModelElement newNode = null;
 		if (lastPart != null) {
 			 selection = lastPart.getSite().getSelectionProvider().getSelection();
 			
@@ -104,9 +104,9 @@ public abstract class NodeSectionSupport extends AbstractPropertySection {
 		CamelEditorUIActivator.pluginLog().logInfo("After " + this + " about to be shown selection " + selection + " node: " + newNode + " last part: " + lastPart);
 	}
 
-	protected void setSelectedNode(CamelModelElement newNode) {
+	protected void setSelectedNode(AbstractCamelModelElement newNode) {
 		if (newNode != null) {
-			CamelModelElement lastNode = node;
+			AbstractCamelModelElement lastNode = node;
 			// lets avoid this check just in case we sometimes lose an event
 			// if (lastNode == newNode || newNode == null) {
 			node = newNode;
@@ -114,16 +114,16 @@ public abstract class NodeSectionSupport extends AbstractPropertySection {
 		}
 	}
 
-	protected abstract void onNodeChanged(CamelModelElement node);
+	protected abstract void onNodeChanged(AbstractCamelModelElement node);
 
-	public CamelModelElement getNode() {
+	public AbstractCamelModelElement getNode() {
 		return node;
 	}
 
 	/**
 	 * Returns the node container
 	 */
-	public CamelModelElement getNodeContainer() {
+	public AbstractCamelModelElement getNodeContainer() {
 		if (node != null) {
 			return node.getParent();
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/CamelEditorContextMenuProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/CamelEditorContextMenuProvider.java
@@ -20,7 +20,7 @@ import org.eclipse.jface.action.Separator;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.handler.AutoLayoutAction;
 import org.fusesource.ide.camel.editor.utils.INodeViewer;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -71,7 +71,7 @@ public class CamelEditorContextMenuProvider extends ContextMenuProvider {
 	@Override
 	public void buildContextMenu(IMenuManager menu) {
 		// add the delete route if a route is selected
-		CamelModelElement node = nodeViewer.getSelectedNode();
+		AbstractCamelModelElement node = nodeViewer.getSelectedNode();
 		if (node == null) {
 			// lets choose the root container
 			node = editor.getModel().getCamelContext();

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/CamelFeatureProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/CamelFeatureProvider.java
@@ -57,7 +57,7 @@ import org.fusesource.ide.camel.editor.features.misc.UpdateNodeFeature;
 import org.fusesource.ide.camel.editor.internal.CamelModelIndependenceSolver;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
 import org.fusesource.ide.camel.model.service.core.model.CamelEndpoint;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.ui.archetypes.BeanDef;
 
 /**
@@ -85,7 +85,7 @@ public class CamelFeatureProvider extends DefaultFeatureProvider {
 		// is object for add request a EClass or EReference?
 		if (context.getNewObject() instanceof CamelElementConnection) {
 			return new AddFlowFeature(this);
-		} else if (context.getNewObject() instanceof CamelModelElement) {
+		} else if (context.getNewObject() instanceof AbstractCamelModelElement) {
 			return new AddNodeFeature(this);
 		}
 		return super.getAddFeature(context);
@@ -128,7 +128,7 @@ public class CamelFeatureProvider extends DefaultFeatureProvider {
 		PictogramElement pictogramElement = context.getPictogramElement();
 		if (pictogramElement instanceof ContainerShape) {
 			Object bo = getBusinessObjectForPictogramElement(pictogramElement);
-			if (bo instanceof CamelModelElement) {
+			if (bo instanceof AbstractCamelModelElement) {
 				return new UpdateNodeFeature(this);
 			}
 		}
@@ -161,7 +161,7 @@ public class CamelFeatureProvider extends DefaultFeatureProvider {
 	public IResizeShapeFeature getResizeShapeFeature(IResizeShapeContext context) {
 		Shape shape = context.getShape();
 		Object bo = getBusinessObjectForPictogramElement(shape);
-		if (bo instanceof CamelModelElement) {
+		if (bo instanceof AbstractCamelModelElement) {
 			return new ResizeNodeFeature(this);
 		}
 		return super.getResizeShapeFeature(context);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ImageProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ImageProvider.java
@@ -20,7 +20,7 @@ import org.eclipse.graphiti.ui.platform.AbstractImageProvider;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.osgi.framework.Bundle;
 
@@ -155,7 +155,7 @@ public class ImageProvider extends AbstractImageProvider {
 	 * @param fileNameSmall	the file name of the small icon
 	 * @param fileNameLarge	the file name of the large icon
 	 */
-	public void addIconsForClass(CamelModelElement node, String fileNameSmall, String fileNameLarge) {
+	public void addIconsForClass(AbstractCamelModelElement node, String fileNameSmall, String fileNameLarge) {
 		addIconsForIconName(node.getIconName(), fileNameSmall, fileNameLarge);
 	}
 
@@ -182,7 +182,7 @@ public class ImageProvider extends AbstractImageProvider {
 		CamelEditorUIActivator.getDefault().getImageRegistry().put(key, CamelEditorUIActivator.imageDescriptorFromPlugin(CamelEditorUIActivator.PLUGIN_ID, path));
 	}
 
-	public void addIconsForClass(CamelModelElement node) {
+	public void addIconsForClass(AbstractCamelModelElement node) {
 		addIconsForClass(node, node.getIconName().replaceAll(".png", "16.png"), node.getIconName());
 	}
 	

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ToolBehaviourProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ToolBehaviourProvider.java
@@ -72,7 +72,7 @@ import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
 import org.fusesource.ide.camel.model.service.core.catalog.components.Component;
 import org.fusesource.ide.camel.model.service.core.catalog.components.ComponentModel;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.validation.ValidationFactory;
 import org.fusesource.ide.camel.validation.ValidationResult;
 import org.fusesource.ide.foundation.core.util.Objects;
@@ -189,8 +189,8 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 				}
 
 				String name = "";
-				if (bo instanceof CamelModelElement) {
-					CamelModelElement bo2 = (CamelModelElement) bo;
+				if (bo instanceof AbstractCamelModelElement) {
+					AbstractCamelModelElement bo2 = (AbstractCamelModelElement) bo;
 					if (bo2 != null && bo2.getName() != null) {
 						name = bo2.getName();
 					}
@@ -428,8 +428,8 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 			// and then our own
 			IFeatureProvider featureProvider = getFeatureProvider();
 			Object bo = featureProvider.getBusinessObjectForPictogramElement(pe);
-			if (bo instanceof CamelModelElement) {
-				CamelModelElement node = (CamelModelElement) bo;
+			if (bo instanceof AbstractCamelModelElement) {
+				AbstractCamelModelElement node = (AbstractCamelModelElement) bo;
 
 				ValidationResult res = ValidationFactory.getInstance().validate(node);
 				if (res.getInformationCount() > 0) {
@@ -519,8 +519,8 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 	public String getToolTip(GraphicsAlgorithm ga) {
 		PictogramElement pe = ga.getPictogramElement();
 		Object bo = getFeatureProvider().getBusinessObjectForPictogramElement(pe);
-		if (bo instanceof CamelModelElement) {
-			String name = ((CamelModelElement) bo).getDescription(); // getDisplayToolTip();
+		if (bo instanceof AbstractCamelModelElement) {
+			String name = ((AbstractCamelModelElement) bo).getDescription(); // getDisplayToolTip();
 			if (name != null && !name.isEmpty()) {
 				return name;
 			}
@@ -534,7 +534,7 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 	 */
 	@Override
 	public boolean equalsBusinessObjects(Object o1, Object o2) {
-		if (o1 instanceof CamelModelElement || o2 instanceof CamelModelElement) {
+		if (o1 instanceof AbstractCamelModelElement || o2 instanceof AbstractCamelModelElement) {
 			return Objects.equal(o1, o2);
 		}
 		return super.equalsBusinessObjects(o1, o2);
@@ -548,7 +548,7 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 	public GraphicsAlgorithm[] getClickArea(PictogramElement pe) {
 		IFeatureProvider featureProvider = getFeatureProvider();
 		Object bo = featureProvider.getBusinessObjectForPictogramElement(pe);
-		if (bo instanceof CamelModelElement && !(bo instanceof CamelElementConnection)) {
+		if (bo instanceof AbstractCamelModelElement && !(bo instanceof CamelElementConnection)) {
 			GraphicsAlgorithm rectangle = pe.getGraphicsAlgorithm();
 			return new GraphicsAlgorithm[] { rectangle };
 		}
@@ -563,7 +563,7 @@ public class ToolBehaviourProvider extends DefaultToolBehaviorProvider {
 	public GraphicsAlgorithm getSelectionBorder(PictogramElement pe) {
 		IFeatureProvider featureProvider = getFeatureProvider();
 		Object bo = featureProvider.getBusinessObjectForPictogramElement(pe);
-		if (bo instanceof CamelModelElement) {
+		if (bo instanceof AbstractCamelModelElement) {
 			GraphicsAlgorithm rectangle = pe.getGraphicsAlgorithm();
 			return rectangle;
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ext/ICustomDblClickHandler.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/provider/ext/ICustomDblClickHandler.java
@@ -11,7 +11,7 @@
 
 package org.fusesource.ide.camel.editor.provider.ext;
 
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -25,12 +25,12 @@ public interface ICustomDblClickHandler {
 	 * @param clickedNode	the node which has been dbl clicked
 	 * @return	true if your handler can handle the dbl click on that node, otherwise false
 	 */
-	boolean canHandle(CamelModelElement clickedNode);
+	boolean canHandle(AbstractCamelModelElement clickedNode);
 	
 	/**
 	 * use this method to do whatever action you want to happen when dbl clicking the node
 	 * 
 	 * @param clickedNode	the node which has been dbl clicked
 	 */
-	void handleDoubleClick(CamelModelElement clickedNode);
+	void handleDoubleClick(AbstractCamelModelElement clickedNode);
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/FigureUIFactory.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/FigureUIFactory.java
@@ -32,7 +32,7 @@ import org.eclipse.graphiti.services.IPeCreateService;
 import org.eclipse.graphiti.ui.services.GraphitiUi;
 import org.fusesource.ide.camel.editor.features.custom.CollapseFeature;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 
 /**
@@ -63,7 +63,7 @@ public class FigureUIFactory {
 	 * @param diagram
 	 * @param defaultLabel
 	 */
-	public static void createFigureUI(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, CamelModelElement element, Diagram diagram, String defaultLabel) {
+	public static void createFigureUI(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, AbstractCamelModelElement element, Diagram diagram, String defaultLabel) {
 		if (element instanceof CamelRouteElement) {
 			// special handling for route figures
 			paintRouteFigure(context, fp, containerShape, element, diagram, defaultLabel);
@@ -89,7 +89,7 @@ public class FigureUIFactory {
 	 * @param diagram
 	 * @param defaultLabel
 	 */
-	private static void paintDefaultFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, CamelModelElement element, Diagram diagram, String defaultLabel) {
+	private static void paintDefaultFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, AbstractCamelModelElement element, Diagram diagram, String defaultLabel) {
 		// as default we paint child figures for now
 		paintChildFigure(context, fp, containerShape, element, diagram, defaultLabel);
 	}
@@ -104,7 +104,7 @@ public class FigureUIFactory {
 	 * @param diagram
 	 * @param defaultLabel
 	 */
-	private static void paintContainerFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, CamelModelElement element, Diagram diagram, String defaultLabel) {
+	private static void paintContainerFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, AbstractCamelModelElement element, Diagram diagram, String defaultLabel) {
 		IPeCreateService peCreateService = Graphiti.getPeCreateService();
 
 		// determine font dimensions
@@ -205,7 +205,7 @@ public class FigureUIFactory {
 	 * @param diagram
 	 * @param defaultLabel
 	 */
-	private static void paintRouteFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, CamelModelElement element, Diagram diagram, String defaultLabel) {
+	private static void paintRouteFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, AbstractCamelModelElement element, Diagram diagram, String defaultLabel) {
 		IPeCreateService peCreateService = Graphiti.getPeCreateService();
 
 		// calculate label width and height
@@ -277,7 +277,7 @@ public class FigureUIFactory {
 	 * @param diagram
 	 * @param defaultLabel
 	 */
-	private static void paintChildFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, CamelModelElement element, Diagram diagram, String defaultLabel) {
+	private static void paintChildFigure(IAddContext context, IFeatureProvider fp, ContainerShape containerShape, AbstractCamelModelElement element, Diagram diagram, String defaultLabel) {
 		IPeCreateService peCreateService = Graphiti.getPeCreateService();
 
 		// calculate the label width and height

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/INodeViewer.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/INodeViewer.java
@@ -11,11 +11,11 @@
 
 package org.fusesource.ide.camel.editor.utils;
 
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 public interface INodeViewer {
 
-	CamelModelElement getSelectedNode();
+	AbstractCamelModelElement getSelectedNode();
 
-	void setSelectedNode(CamelModelElement newSelection);
+	void setSelectedNode(AbstractCamelModelElement newSelection);
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/NodeSelectionSupport.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/NodeSelectionSupport.java
@@ -14,14 +14,14 @@ package org.fusesource.ide.camel.editor.utils;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.ui.ISelectionListener;
 import org.eclipse.ui.IWorkbenchPart;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * Helper class to track the selection of a node
  */
 public class NodeSelectionSupport implements ISelectionListener {
 
-	protected CamelModelElement selectedNode;
+	protected AbstractCamelModelElement selectedNode;
 
 	/*
 	 * (non-Javadoc)
@@ -29,7 +29,7 @@ public class NodeSelectionSupport implements ISelectionListener {
 	 */
 	@Override
 	public void selectionChanged(IWorkbenchPart part, ISelection selection) {
-		CamelModelElement lastNode = selectedNode;
+		AbstractCamelModelElement lastNode = selectedNode;
 		selectedNode = NodeUtils.getSelectedNode(selection);
 		if (selectedNode != null) {
 			if (lastNode == selectedNode) {
@@ -43,18 +43,18 @@ public class NodeSelectionSupport implements ISelectionListener {
 	/**
 	 * Override this method to perform some logic when the selected node changes
 	 */
-	protected void onNodeChanged(CamelModelElement node) {
+	protected void onNodeChanged(AbstractCamelModelElement node) {
 		//Activator.getLogger().debug("Selection changed: " + node, null);
 	}
 
-	public CamelModelElement getSelectedNode() {
+	public AbstractCamelModelElement getSelectedNode() {
 		return selectedNode;
 	}
 
 	/**
 	 * Returns the node container
 	 */
-	public CamelModelElement getNodeContainer() {
+	public AbstractCamelModelElement getNodeContainer() {
 		if (selectedNode != null) {
 			return selectedNode.getParent();
 		}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/NodeUtils.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/NodeUtils.java
@@ -26,7 +26,7 @@ import org.fusesource.ide.camel.model.service.core.catalog.CamelModel;
 import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
 import org.fusesource.ide.camel.model.service.core.catalog.Parameter;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.foundation.ui.tree.HasOwner;
 
@@ -48,8 +48,8 @@ public class NodeUtils {
 	public static boolean isMandatory(Object bean, String propertyName) {
 		// lets look at the setter method and see if its got a @Required
 		// annotation
-		if (bean instanceof CamelModelElement) {
-			CamelModelElement node = (CamelModelElement) bean;
+		if (bean instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement node = (AbstractCamelModelElement) bean;
 			Eip eip = node.getUnderlyingMetaModelObject();
 			Parameter p = eip.getParameter(propertyName);
 			if (p != null) {
@@ -66,7 +66,7 @@ public class NodeUtils {
 	 * @param child		the child element
 	 * @return			true if the child is valid for the given container, otherwise false
 	 */
-	public static boolean isValidChild(CamelModelElement parent, CamelModelElement child) {
+	public static boolean isValidChild(AbstractCamelModelElement parent, AbstractCamelModelElement child) {
 		if (parent != null && child != null) {
     		String camelVersion = CamelUtils.getCurrentProjectCamelVersion();
     		CamelModel metaModel = CamelModelFactory.getModelForVersion(camelVersion);
@@ -93,11 +93,11 @@ public class NodeUtils {
 	 * @param context
 	 * @param pes
 	 */
-    public static void getAllContainers(IFeatureProvider fp, CamelModelElement context, ArrayList<PictogramElement> pes) {
+    public static void getAllContainers(IFeatureProvider fp, AbstractCamelModelElement context, ArrayList<PictogramElement> pes) {
 		if (context instanceof CamelRouteElement) {
 			pes.add(fp.getDiagramTypeProvider().getFeatureProvider().getPictogramElementForBusinessObject(context));
 		}
-    	for (CamelModelElement cme : context.getChildElements()) {
+    	for (AbstractCamelModelElement cme : context.getChildElements()) {
 			if (cme.getUnderlyingMetaModelObject() != null && cme.getUnderlyingMetaModelObject().canHaveChildren()) {
 				pes.add(fp.getDiagramTypeProvider().getFeatureProvider().getPictogramElementForBusinessObject(cme));
 			}
@@ -107,10 +107,10 @@ public class NodeUtils {
 		}
 	}
 
-    public static CamelModelElement toCamelElement(Object input) {
-		CamelModelElement answer = null;
-		if (input instanceof CamelModelElement) {
-			return (CamelModelElement) input;
+    public static AbstractCamelModelElement toCamelElement(Object input) {
+		AbstractCamelModelElement answer = null;
+		if (input instanceof AbstractCamelModelElement) {
+			return (AbstractCamelModelElement) input;
 // TODO: check what AbstractNodeFacade is about and how to migrate if needed
 //		} else if (input instanceof AbstractNodeFacade) {
 //			AbstractNodeFacade facade = (AbstractNodeFacade) input;
@@ -125,7 +125,7 @@ public class NodeUtils {
 					answer = CamelUtils.getDiagramEditor().getSelectedContainer() != null ? CamelUtils.getDiagramEditor().getSelectedContainer() : CamelUtils.getDiagramEditor().getModel();				
 				} else {
 					// select the node
-					answer = (CamelModelElement)CamelUtils.getDiagramEditor().getFeatureProvider().getBusinessObjectForPictogramElement(element);
+					answer = (AbstractCamelModelElement)CamelUtils.getDiagramEditor().getFeatureProvider().getBusinessObjectForPictogramElement(element);
 				}
 			}
 		} else if (input instanceof AbstractEditPart) {
@@ -134,10 +134,10 @@ public class NodeUtils {
 			answer = toCamelElement(model);
 		} else if (input instanceof ContainerShape) {
 			ContainerShape shape = (ContainerShape) input;
-			answer = (CamelModelElement)CamelUtils.getDiagramEditor().getFeatureProvider().getBusinessObjectForPictogramElement(shape);
+			answer = (AbstractCamelModelElement)CamelUtils.getDiagramEditor().getFeatureProvider().getBusinessObjectForPictogramElement(shape);
 		}
 		if (input != null && answer == null) {
-			answer = (CamelModelElement) Platform.getAdapterManager().getAdapter(input, CamelModelElement.class);
+			answer = (AbstractCamelModelElement) Platform.getAdapterManager().getAdapter(input, AbstractCamelModelElement.class);
 		}
 		if (answer == null && input instanceof HasOwner) {
 			HasOwner ho = (HasOwner) input;
@@ -146,8 +146,8 @@ public class NodeUtils {
 		return answer;
 	}
     
-    public static CamelModelElement getSelectedNode(ISelection selection) {
-    	CamelModelElement answer = null;
+    public static AbstractCamelModelElement getSelectedNode(ISelection selection) {
+    	AbstractCamelModelElement answer = null;
 		if (selection instanceof IStructuredSelection) {
 			Object input = ((IStructuredSelection) selection).getFirstElement();
 			answer = toCamelElement(input);

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelConditionalBreakpoint.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelConditionalBreakpoint.java
@@ -23,7 +23,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IBreakpoint;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.launcher.debug.util.CamelDebugRegistry;
 import org.fusesource.ide.launcher.debug.util.CamelDebugRegistryEntry;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
@@ -56,7 +56,7 @@ public class CamelConditionalBreakpoint extends CamelEndpointBreakpoint {
 	 * @param conditionPredicate
 	 * @throws CoreException
 	 */
-	public CamelConditionalBreakpoint(final IResource resource, final CamelModelElement endpoint, final String projectName, final String fileName, String language, String conditionPredicate)
+	public CamelConditionalBreakpoint(final IResource resource, final AbstractCamelModelElement endpoint, final String projectName, final String fileName, String language, String conditionPredicate)
 			throws CoreException {
 		this.endpointNodeId = endpoint.getId();
 		this.contextId = endpoint.getCamelContext().getId();

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelEndpointBreakpoint.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelEndpointBreakpoint.java
@@ -24,7 +24,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.Breakpoint;
 import org.eclipse.debug.core.model.IBreakpoint;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.launcher.debug.util.CamelDebugRegistry;
 import org.fusesource.ide.launcher.debug.util.CamelDebugRegistryEntry;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
@@ -60,7 +60,7 @@ public class CamelEndpointBreakpoint extends Breakpoint {
 	 * @param endpoint the endpoint
 	 * @throws CoreException if unable to create the breakpoint
 	 */
-	public CamelEndpointBreakpoint(final IResource resource, final CamelModelElement endpoint, final String projectName, final String fileName)
+	public CamelEndpointBreakpoint(final IResource resource, final AbstractCamelModelElement endpoint, final String projectName, final String fileName)
 			throws CoreException {
 		this.endpointNodeId = endpoint.getId();
 		this.contextId = endpoint.getCamelContext().getId();

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/util/CamelDebugUtils.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/util/CamelDebugUtils.java
@@ -30,7 +30,7 @@ import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.model.IBreakpoint;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.launcher.Activator;
 import org.fusesource.ide.launcher.debug.model.CamelConditionalBreakpoint;
@@ -131,7 +131,7 @@ public class CamelDebugUtils {
 	 * @return				the created breakpoint
 	 * @throws CoreException
 	 */
-	public static IBreakpoint createAndRegisterEndpointBreakpoint(IResource resource, CamelModelElement endpoint, String projectName, String fileName) throws CoreException {
+	public static IBreakpoint createAndRegisterEndpointBreakpoint(IResource resource, AbstractCamelModelElement endpoint, String projectName, String fileName) throws CoreException {
     	CamelEndpointBreakpoint epb = new CamelEndpointBreakpoint(resource, endpoint, projectName, fileName);
     	DebugPlugin.getDefault().getBreakpointManager().addBreakpoint(epb);
     	return epb;
@@ -149,7 +149,7 @@ public class CamelDebugUtils {
 	 * @return				the created breakpoint
 	 * @throws CoreException
 	 */
-	public static IBreakpoint createAndRegisterConditionalBreakpoint(IResource resource, CamelModelElement endpoint, String projectName, String fileName, String language, String condition) throws CoreException {
+	public static IBreakpoint createAndRegisterConditionalBreakpoint(IResource resource, AbstractCamelModelElement endpoint, String projectName, String fileName, String language, String condition) throws CoreException {
     	CamelConditionalBreakpoint epb = new CamelConditionalBreakpoint(resource, endpoint, projectName, fileName, language, condition);
     	DebugPlugin.getDefault().getBreakpointManager().addBreakpoint(epb);
     	return epb;

--- a/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/decorator/CamelRouteProblemDecorator.java
+++ b/editor/plugins/org.fusesource.ide.project/src/org/fusesource/ide/project/decorator/CamelRouteProblemDecorator.java
@@ -20,7 +20,7 @@ import org.eclipse.jface.viewers.ILightweightLabelDecorator;
 import org.eclipse.ui.ISharedImages;
 import org.eclipse.ui.PlatformUI;
 import org.fusesource.ide.camel.editor.navigator.CamelCtxNavRouteNode;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.camel.validation.diagram.IFuseMarker;
 import org.fusesource.ide.project.Activator;
@@ -103,7 +103,7 @@ public class CamelRouteProblemDecorator implements ILightweightLabelDecorator {
 	 * @return if the Camel Element with 'id' is inside the 'camelRoute'
 	 */
 	private boolean isInsideRoute(CamelRouteElement camelRoute, String id) {
-		CamelModelElement current = ((CamelRouteElement) camelRoute).getCamelFile().findNode(id);
+		AbstractCamelModelElement current = ((CamelRouteElement) camelRoute).getCamelFile().findNode(id);
 		while (current != null) {
 			if (camelRoute.equals(current)) {
 				return true;

--- a/editor/tests/org.fusesource.ide.camel.editor.tests/src-test/java/org/fusesource/ide/camel/editor/properties/CamelTypeMapperTest.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests/src-test/java/org/fusesource/ide/camel/editor/properties/CamelTypeMapperTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.camel.editor.properties;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.graphiti.ui.internal.parts.ContainerShapeEditPart;
+import org.fusesource.ide.camel.model.service.core.model.CamelBasicModelElement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CamelTypeMapperTest {
+
+	@Spy
+	CamelTypeMapper camelTypeMapper;
+
+	@Mock
+	ContainerShapeEditPart editPart;
+
+	@Test
+	public void testMapType_CamelNode() throws Exception {
+		Mockito.doReturn(new CamelBasicModelElement(null, null)).when(camelTypeMapper).resolveCamelModelElement(Mockito.any(ContainerShapeEditPart.class));
+		Assertions.assertThat(camelTypeMapper.mapType(editPart)).isEqualTo(CamelBasicModelElement.class);
+	}
+
+	@Test
+	public void testMapType_OtherStuff() throws Exception {
+		Mockito.doReturn(null).when(camelTypeMapper).resolveCamelModelElement(Mockito.any());
+		Assertions.assertThat(camelTypeMapper.mapType(new Object())).isEqualTo(Object.class);
+	}
+
+}

--- a/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/ProcessorNode.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/ProcessorNode.java
@@ -15,7 +15,7 @@ import java.util.List;
 
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.swt.graphics.Image;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.jmx.camel.CamelJMXPlugin;
 import org.jboss.tools.jmx.core.tree.Node;
 
@@ -24,9 +24,9 @@ public class ProcessorNode extends ProcessorNodeSupport {
 	private static final boolean useCaching = true;
 
 	private final RouteNode routeNode;
-	private final CamelModelElement node;
+	private final AbstractCamelModelElement node;
 
-	public ProcessorNode(RouteNode routeNode, Node parent, CamelModelElement node) {
+	public ProcessorNode(RouteNode routeNode, Node parent, AbstractCamelModelElement node) {
 		super(parent, routeNode.getRoute());
 		this.routeNode = routeNode;
 		this.node = node;
@@ -44,11 +44,11 @@ public class ProcessorNode extends ProcessorNodeSupport {
 
 	@Override
 	protected void loadChildren() {
-		List<CamelModelElement> children = node.getChildElements(); //getOutputs()
+		List<AbstractCamelModelElement> children = node.getChildElements(); //getOutputs()
 		if (node.getOutputElement() != null) {
 			addChild(new ProcessorNode(routeNode, this, node.getOutputElement()));
 		}
-		for (CamelModelElement pnode : children) {
+		for (AbstractCamelModelElement pnode : children) {
 			if (pnode.getInputElement() == null) {
 				addChild(new ProcessorNode(routeNode, this, pnode));
 			}

--- a/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/RouteNode.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/RouteNode.java
@@ -18,7 +18,7 @@ import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.Image;
 import org.fusesource.ide.camel.model.service.core.jmx.camel.CamelRouteMBean;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.foundation.core.functions.Function1;
 import org.fusesource.ide.foundation.core.util.Objects;
@@ -60,8 +60,8 @@ public class RouteNode extends ProcessorNodeSupport implements ImageProvider {
 
 	@Override
 	protected void loadChildren() {
-		List<CamelModelElement> children = route.getChildElements();
-		for (CamelModelElement node : children) {
+		List<AbstractCamelModelElement> children = route.getChildElements();
+		for (AbstractCamelModelElement node : children) {
 			if (node.getInputElement() == null) {
 				addChild(new ProcessorNode(this, this, node));
 			}

--- a/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/RoutesNode.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.camel/src/org/fusesource/ide/jmx/camel/navigator/RoutesNode.java
@@ -24,7 +24,7 @@ import org.eclipse.ui.views.properties.IPropertySource;
 import org.fusesource.ide.camel.model.service.core.jmx.camel.CamelJMXFacade;
 import org.fusesource.ide.camel.model.service.core.jmx.camel.CamelRouteMBean;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.foundation.ui.tree.RefreshableCollectionNode;
 import org.fusesource.ide.foundation.ui.util.ContextMenuProvider;
@@ -82,8 +82,8 @@ public class RoutesNode extends RefreshableCollectionNode implements ContextMenu
 		Map<String,RouteNode> routeMap = new HashMap<String, RouteNode>();
 		camelContext = getCamelContextNode().getCamelContext();
 		if (camelContext != null) {
-			List<CamelModelElement> children = camelContext.getChildElements();
-			for (CamelModelElement node : children) {
+			List<AbstractCamelModelElement> children = camelContext.getChildElements();
+			for (AbstractCamelModelElement node : children) {
 				if (node instanceof CamelRouteElement) {
 					CamelRouteElement route = (CamelRouteElement) node;
 					RouteNode routeNode = new RouteNode(this, route);

--- a/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/DiagramGraphLabelProvider.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/DiagramGraphLabelProvider.java
@@ -34,7 +34,7 @@ import org.eclipse.zest.core.viewers.IEntityStyleProvider;
 import org.eclipse.zest.core.widgets.ZestStyles;
 import org.fusesource.ide.camel.editor.utils.DiagramUtils;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.graph.GraphLabelProviderSupport;
 import org.fusesource.ide.jmx.commons.Activator;
@@ -49,7 +49,7 @@ public class DiagramGraphLabelProvider extends GraphLabelProviderSupport impleme
 IEntityStyleProvider, IConnectionStyleProvider,
 ISelectionChangedListener {
 	private final DiagramView view;
-	private Set<CamelModelElement> selectedConnections;
+	private Set<AbstractCamelModelElement> selectedConnections;
 	private NumberFormat numberFormat = NumberFormat.getInstance();
 	private boolean useNodeIdForLabel;
 
@@ -68,7 +68,7 @@ ISelectionChangedListener {
 	public void selectionChanged(SelectionChangedEvent event) {
 		GraphViewer viewer = getViewer();
 		if (selectedConnections != null) {
-			for (CamelModelElement node : selectedConnections) {
+			for (AbstractCamelModelElement node : selectedConnections) {
 				viewer.unReveal(node);
 			}
 			selectedConnections = null;
@@ -76,10 +76,10 @@ ISelectionChangedListener {
 
 		ISelection selection = event.getSelection();
 		if (!selection.isEmpty() && selection instanceof IStructuredSelection) {
-			selectedConnections = new HashSet<CamelModelElement>();
+			selectedConnections = new HashSet<AbstractCamelModelElement>();
 			for (Object o : ((IStructuredSelection) selection).toList()) {
-				if (o instanceof CamelModelElement) {
-					CamelModelElement node = (CamelModelElement) o;
+				if (o instanceof AbstractCamelModelElement) {
+					AbstractCamelModelElement node = (AbstractCamelModelElement) o;
 					viewer.reveal(node);
 					selectedConnections.add(node);
 					/*
@@ -132,7 +132,7 @@ ISelectionChangedListener {
 	public Image getImage(Object element) {
 		if (isShowIcon()) {
 			if (isRouteNode(element)) {
-				CamelModelElement node = (CamelModelElement) element;
+				AbstractCamelModelElement node = (AbstractCamelModelElement) element;
 				return Activator.getDefault().getImage(node.getIconName().replaceAll(".png", "16.png"));
 			}
 			if (element instanceof ImageProvider) {
@@ -144,7 +144,7 @@ ISelectionChangedListener {
 	}
 
 	protected boolean isRouteNode(Object element) {
-		return element instanceof CamelModelElement && !(element instanceof CamelElementConnection);
+		return element instanceof AbstractCamelModelElement && !(element instanceof CamelElementConnection);
 	}
 
 	/*
@@ -155,7 +155,7 @@ ISelectionChangedListener {
 	public String getText(Object element) {
 		try {
 			if (isRouteNode(element)) {
-				CamelModelElement node = (CamelModelElement) element;
+				AbstractCamelModelElement node = (AbstractCamelModelElement) element;
 				String label = node.getDisplayText(useNodeIdForLabel);
 				return label;
 			} else if (element instanceof HasName) {
@@ -190,7 +190,7 @@ ISelectionChangedListener {
 	@Override
 	public IFigure getTooltip(Object entity) {
 		if (isRouteNode(entity)) {
-			CamelModelElement node = (CamelModelElement) entity;
+			AbstractCamelModelElement node = (AbstractCamelModelElement) entity;
 			String label = node.getDescription();
 
 			String id = node.getId();
@@ -215,7 +215,7 @@ ISelectionChangedListener {
 	protected INodeStatistics getStatsFor(CamelElementConnection flow) {
 		NodeStatisticsContainer traceExchangeList = view.getNodeStatisticsContainer();
 		INodeStatistics stats = null;
-		CamelModelElement node = flow.getTarget();
+		AbstractCamelModelElement node = flow.getTarget();
 		if (traceExchangeList != null && node != null) {
 			stats = traceExchangeList.getNodeStats(node.getId());
 		}

--- a/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/DiagramView.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/DiagramView.java
@@ -21,7 +21,7 @@ import org.eclipse.ui.IWorkbenchPart;
 import org.eclipse.ui.PartInitException;
 import org.fusesource.ide.camel.editor.CamelEditor;
 import org.fusesource.ide.camel.editor.utils.NodeUtils;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.foundation.core.util.Objects;
 import org.fusesource.ide.foundation.ui.util.Selections;
@@ -46,7 +46,7 @@ public class DiagramView extends GraphViewSupport {
 	public static final String ID = "org.fusesource.ide.jmx.views.DiagramView";
 
 	private Node selectedNode;
-	CamelModelElement node;
+	AbstractCamelModelElement node;
 	private NodeStatisticsContainer nodeStatisticsContainer;
 
 	private IWorkbenchPart selectionPart;
@@ -129,7 +129,7 @@ public class DiagramView extends GraphViewSupport {
 //						setSelectedObjectOnly(null);
 //					}
 					
-					CamelModelElement node = NodeUtils.getSelectedNode(selection);
+					AbstractCamelModelElement node = NodeUtils.getSelectedNode(selection);
 					if (node != null && !(part instanceof CamelEditor)) {
 						//Activator.getLogger().debug("Part is: " + part + " of type : " + part.getClass());
 						if (node != DiagramView.this.node) {
@@ -197,7 +197,7 @@ public class DiagramView extends GraphViewSupport {
 		this.viewer.refresh();
 	}
 	
-	public void updateGraph(CamelModelElement node, IWorkbenchPart part) {
+	public void updateGraph(AbstractCamelModelElement node, IWorkbenchPart part) {
 		this.node = node;
 		this.selectionPart = part;
 		RouteGraphContentProvider contentProvider = new RouteGraphContentProvider();
@@ -220,9 +220,9 @@ public class DiagramView extends GraphViewSupport {
 
 	protected boolean selectNodeId(String toNode, String endpointUri) {
 		if (node != null) {
-			CamelModelElement parent = getParentContainer();
+			AbstractCamelModelElement parent = getParentContainer();
 			if (parent != null) {
-				CamelModelElement newSelection = parent.findNode(toNode);
+				AbstractCamelModelElement newSelection = parent.findNode(toNode);
 				if (newSelection != null) {
 					if (newSelection instanceof CamelRouteElement) {
 						// okay its the route we want to select, but we dont display the route node itself
@@ -249,10 +249,10 @@ public class DiagramView extends GraphViewSupport {
 
 	protected boolean selectEndpointUri(String uri) {
 		if (node != null) {
-			CamelModelElement parent = getParentContainer();
+			AbstractCamelModelElement parent = getParentContainer();
 			if (parent instanceof CamelRouteElement) {
 				CamelRouteElement route = (CamelRouteElement) parent;
-				CamelModelElement newSelection = route.findEndpoint(uri);
+				AbstractCamelModelElement newSelection = route.findEndpoint(uri);
 				if (newSelection != null) {
 					viewer.setSelection(new StructuredSelection(newSelection));
 					return true;
@@ -263,7 +263,7 @@ public class DiagramView extends GraphViewSupport {
 	}
 
 
-	protected CamelModelElement getParentContainer() {
+	protected AbstractCamelModelElement getParentContainer() {
 		return node.getParent();
 	}
 

--- a/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/NodeGraphContentProvider.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/NodeGraphContentProvider.java
@@ -19,7 +19,7 @@ import java.util.Set;
 import org.eclipse.jface.viewers.IStructuredContentProvider;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.IGraphEntityContentProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 import org.fusesource.ide.jmx.commons.tree.ConnectedNode;
 import org.fusesource.ide.jmx.commons.tree.GraphableNode;
@@ -52,10 +52,10 @@ public class NodeGraphContentProvider implements  IStructuredContentProvider, IG
 	 */
 	@Override
 	public Object[] getElements(Object input) {
-		if (input instanceof CamelModelElement) {
-			CamelModelElement node = (CamelModelElement) input;
+		if (input instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement node = (AbstractCamelModelElement) input;
 
-			Set<CamelModelElement> set = new HashSet<CamelModelElement>();
+			Set<AbstractCamelModelElement> set = new HashSet<AbstractCamelModelElement>();
 			CamelRouteElement parent;
 			if (node instanceof CamelRouteElement) {
 				parent = (CamelRouteElement) node;
@@ -88,8 +88,8 @@ public class NodeGraphContentProvider implements  IStructuredContentProvider, IG
 		}
 	}
 	
-	private CamelRouteElement getRoute(CamelModelElement e) {
-		CamelModelElement cme = e;
+	private CamelRouteElement getRoute(AbstractCamelModelElement e) {
+		AbstractCamelModelElement cme = e;
 		while (cme != null && cme instanceof CamelRouteElement == false) {
 			cme = cme.getParent();
 		}
@@ -99,12 +99,12 @@ public class NodeGraphContentProvider implements  IStructuredContentProvider, IG
 		return null;
 	}
 
-	private void getAllOutputs(CamelModelElement elem, Set<CamelModelElement> set) {
+	private void getAllOutputs(AbstractCamelModelElement elem, Set<AbstractCamelModelElement> set) {
 		if (elem.getOutputElement() != null) set.add(elem.getOutputElement());
 	}
 	
-	private void getAllChildren(List<CamelModelElement> elems, Set<CamelModelElement> set) {
-		for (CamelModelElement e : elems) {
+	private void getAllChildren(List<AbstractCamelModelElement> elems, Set<AbstractCamelModelElement> set) {
+		for (AbstractCamelModelElement e : elems) {
 			set.add(e);
 			getAllOutputs(e, set);
 			if (e.getChildElements().isEmpty() == false) {
@@ -121,8 +121,8 @@ public class NodeGraphContentProvider implements  IStructuredContentProvider, IG
 		} else if (entity instanceof CamelRouteElement) {
 			CamelRouteElement route = (CamelRouteElement) entity;
 			return route.getInputs().toArray();
-		} else if (entity instanceof CamelModelElement) {
-			CamelModelElement node = (CamelModelElement) entity;
+		} else if (entity instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement node = (AbstractCamelModelElement) entity;
 			return new Object[] {node.getOutputElement()};
 		} else if (entity instanceof ConnectedNode) {
 			ConnectedNode node = (ConnectedNode) entity;

--- a/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/RouteGraphContentProvider.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/views/diagram/RouteGraphContentProvider.java
@@ -18,7 +18,7 @@ import java.util.Set;
 import org.eclipse.jface.viewers.Viewer;
 import org.eclipse.zest.core.viewers.IGraphContentProvider;
 import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
 
 public class RouteGraphContentProvider implements IGraphContentProvider {
@@ -73,8 +73,8 @@ public class RouteGraphContentProvider implements IGraphContentProvider {
 	public Object[] getElements(Object input) {
 		if (input instanceof Object[]) {
 			return (Object[]) input;
-		} else if (input instanceof CamelModelElement) {
-			CamelModelElement node = (CamelModelElement) input;
+		} else if (input instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement node = (AbstractCamelModelElement) input;
 
 			Set<CamelElementConnection> set = new HashSet<CamelElementConnection>();
 			CamelRouteElement parent;
@@ -83,7 +83,7 @@ public class RouteGraphContentProvider implements IGraphContentProvider {
 			} else {
 				parent = getRoute(node);
 			}
-			Set<CamelModelElement> descendents = new HashSet<CamelModelElement>();
+			Set<AbstractCamelModelElement> descendents = new HashSet<AbstractCamelModelElement>();
 			if (parent == null) {
 				getAllChildren(node.getChildElements(), descendents);
 			} else {
@@ -94,12 +94,12 @@ public class RouteGraphContentProvider implements IGraphContentProvider {
 		return null;
 	}
 	
-	private void getAllOutputs(CamelModelElement elem, Set<CamelModelElement> set) {
+	private void getAllOutputs(AbstractCamelModelElement elem, Set<AbstractCamelModelElement> set) {
 		if (elem.getOutputElement() != null) set.add(elem.getOutputElement());
 	}
 	
-	private void getAllChildren(List<CamelModelElement> elems, Set<CamelModelElement> set) {
-		for (CamelModelElement e : elems) {
+	private void getAllChildren(List<AbstractCamelModelElement> elems, Set<AbstractCamelModelElement> set) {
+		for (AbstractCamelModelElement e : elems) {
 			set.add(e);
 			getAllOutputs(e, set);
 			if (e.getChildElements().isEmpty() == false) {
@@ -108,8 +108,8 @@ public class RouteGraphContentProvider implements IGraphContentProvider {
 		}
 	}
 	
-	private CamelRouteElement getRoute(CamelModelElement e) {
-		CamelModelElement cme = e;
+	private CamelRouteElement getRoute(AbstractCamelModelElement e) {
+		AbstractCamelModelElement cme = e;
 		while (cme != null && cme instanceof CamelRouteElement == false) {
 			cme = cme.getParent();
 		}

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.core/src/org/jboss/tools/fuse/transformation/core/camel/CamelConfigBuilder.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.core/src/org/jboss/tools/fuse/transformation/core/camel/CamelConfigBuilder.java
@@ -22,9 +22,10 @@ import org.fusesource.ide.camel.model.service.core.catalog.CamelModel;
 import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
 import org.fusesource.ide.camel.model.service.core.catalog.eips.Eip;
 import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelBasicModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelEndpoint;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
 import org.jboss.tools.fuse.transformation.core.TransformType;
 
 /**
@@ -68,9 +69,9 @@ public class CamelConfigBuilder {
 	 * @return
 	 * @throws Exception
 	 */
-    public CamelModelElement createDataFormat(TransformType type, String className, MarshalType marshalType) throws Exception {
+    public AbstractCamelModelElement createDataFormat(TransformType type, String className, MarshalType marshalType) throws Exception {
         
-    	CamelModelElement dataFormat = null;
+    	AbstractCamelModelElement dataFormat = null;
 
         switch (type) {
             case JSON:
@@ -101,7 +102,7 @@ public class CamelConfigBuilder {
      * @param marshaller
      * @return
      */
-    public CamelModelElement createEndpoint(String transformId, String dozerConfigPath, String sourceClass, String targetClass, CamelModelElement unmarshaller, CamelModelElement marshaller) {
+    public AbstractCamelModelElement createEndpoint(String transformId, String dozerConfigPath, String sourceClass, String targetClass, AbstractCamelModelElement unmarshaller, AbstractCamelModelElement marshaller) {
         String unmarshallerId = unmarshaller != null ? unmarshaller.getId() : null;
         String marshallerId = marshaller != null ? marshaller.getId() : null;
         String endpointUri = EndpointHelper.createEndpointUri(dozerConfigPath,
@@ -127,8 +128,8 @@ public class CamelConfigBuilder {
             TransformType target, String targetClass) throws Exception {
 
         // Add data formats
-    	CamelModelElement unmarshaller = createDataFormat(source, sourceClass, MarshalType.UNMARSHALLER);
-    	CamelModelElement marshaller = createDataFormat(target, targetClass, MarshalType.MARSHALLER);
+    	AbstractCamelModelElement unmarshaller = createDataFormat(source, sourceClass, MarshalType.UNMARSHALLER);
+    	AbstractCamelModelElement marshaller = createDataFormat(target, targetClass, MarshalType.MARSHALLER);
 
         // Create a transformation endpoint
         String unmarshallerId = unmarshaller != null ? unmarshaller.getId() : null;
@@ -137,9 +138,9 @@ public class CamelConfigBuilder {
         addEndpoint(transformId, endpointUri);
     }
 
-    public CamelModelElement getEndpoint(String endpointId) {
-    	CamelModelElement endpoint = null;
-        for (CamelModelElement ep : getEndpoints()) {
+    public AbstractCamelModelElement getEndpoint(String endpointId) {
+    	AbstractCamelModelElement endpoint = null;
+        for (AbstractCamelModelElement ep : getEndpoints()) {
             if (endpointId.equals(ep.getId())) {
                 endpoint = ep;
                 break;
@@ -150,7 +151,7 @@ public class CamelConfigBuilder {
 
     public List<String> getTransformEndpointIds() {
         List<String> endpointIds = new LinkedList<String>();
-        for (CamelModelElement ep : getEndpoints()) {
+        for (AbstractCamelModelElement ep : getEndpoints()) {
             if (((String)ep.getParameter("uri")).startsWith(EndpointHelper.DOZER_SCHEME)) {
                 endpointIds.add(ep.getId());
             }
@@ -158,9 +159,9 @@ public class CamelConfigBuilder {
         return endpointIds;
     }
 
-    public CamelModelElement getDataFormat(String id) {
-    	CamelModelElement dataFormat = null;
-        for (CamelModelElement df : getDataFormats()) {
+    public AbstractCamelModelElement getDataFormat(String id) {
+    	AbstractCamelModelElement dataFormat = null;
+        for (AbstractCamelModelElement df : getDataFormats()) {
             if (id.equals(df.getId())) {
                 dataFormat = df;
                 break;
@@ -169,16 +170,16 @@ public class CamelConfigBuilder {
         return dataFormat;
     }
 
-    public Collection<CamelModelElement> getDataFormats() {
+    public Collection<AbstractCamelModelElement> getDataFormats() {
     	return getModel().getCamelContext().getDataformats().values();
     }
 
-    public Collection<CamelModelElement> getEndpoints() {
+    public Collection<AbstractCamelModelElement> getEndpoints() {
     	return getModel().getCamelContext().getEndpointDefinitions().values();
     }
 
-    protected CamelModelElement addEndpoint(String id, String uri) {
-    	CamelModelElement parent = getModel().getCamelContext();
+    protected AbstractCamelModelElement addEndpoint(String id, String uri) {
+    	AbstractCamelModelElement parent = getModel().getCamelContext();
 		CamelEndpoint ep = new CamelEndpoint(uri);
 		ep.setId(id);
 		ep.setParent(parent);
@@ -192,14 +193,14 @@ public class CamelConfigBuilder {
         return idx > 0 ? type.substring(0, idx) : type;
     }
 
-    protected CamelModelElement createJsonDataFormat(String className) throws Exception {
+    protected AbstractCamelModelElement createJsonDataFormat(String className) throws Exception {
         final String id = className != null ? className.replaceAll("\\.", "") : "transform-json";
         Eip json = getEipByName("json");
-        CamelModelElement dataFormat = getDataFormat(id);
+        AbstractCamelModelElement dataFormat = getDataFormat(id);
         if (dataFormat == null) {
             // Looks like we need to create a new one
-        	CamelModelElement parent = getModel().getCamelContext();
-    		dataFormat = new CamelModelElement(parent, null);
+        	AbstractCamelModelElement parent = getModel().getCamelContext();
+			dataFormat = new CamelBasicModelElement(parent, null);
     		dataFormat.setId(id);
     		dataFormat.setUnderlyingMetaModelObject(json);
     		dataFormat.setParameter("library", "Jackson");
@@ -210,14 +211,14 @@ public class CamelConfigBuilder {
     }
 
 
-    protected CamelModelElement createJaxbDataFormat(String contextPath) throws Exception {
+    protected AbstractCamelModelElement createJaxbDataFormat(String contextPath) throws Exception {
         final String id = contextPath.replaceAll("\\.", "");
         Eip jaxb = getEipByName("jaxb");
-        CamelModelElement dataFormat = getDataFormat(id);
+        AbstractCamelModelElement dataFormat = getDataFormat(id);
         if (dataFormat == null) {
             // Looks like we need to create a new one
-        	CamelModelElement parent = getModel().getCamelContext();
-    		dataFormat = new CamelModelElement(parent, null);
+        	AbstractCamelModelElement parent = getModel().getCamelContext();
+			dataFormat = new CamelBasicModelElement(parent, null);
     		dataFormat.setId(id);
     		dataFormat.setUnderlyingMetaModelObject(jaxb);
     		dataFormat.setParameter("contextPath", contextPath);

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.core/src/org/jboss/tools/fuse/transformation/core/camel/EndpointHelper.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.core/src/org/jboss/tools/fuse/transformation/core/camel/EndpointHelper.java
@@ -10,7 +10,7 @@
  ******************************************************************************/
 package org.jboss.tools.fuse.transformation.core.camel;
 
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * Utility methods that help with constructing or modifying a transformation
@@ -49,15 +49,15 @@ public final class EndpointHelper {
         return uriBuf.toString();
     }
 
-    public static void setSourceModel(CamelModelElement endpoint, String sourceModel) {
+    public static void setSourceModel(AbstractCamelModelElement endpoint, String sourceModel) {
         replaceEndpointParameter(endpoint, SOURCE_MODEL, sourceModel);
     }
 
-    public static void setTargetModel(CamelModelElement endpoint, String targetModel) {
+    public static void setTargetModel(AbstractCamelModelElement endpoint, String targetModel) {
         replaceEndpointParameter(endpoint, TARGET_MODEL, targetModel);
     }
 
-    public static void replaceEndpointParameter(CamelModelElement endpoint, String key, String val) {
+    public static void replaceEndpointParameter(AbstractCamelModelElement endpoint, String key, String val) {
 
         StringBuilder uriStr = new StringBuilder((String)endpoint.getParameter("uri"));
         if (uriStr.indexOf(key + "=") < 0) {

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/TransformationEditor.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/TransformationEditor.java
@@ -62,7 +62,7 @@ import org.eclipse.ui.part.EditorPart;
 import org.eclipse.ui.part.FileEditorInput;
 import org.fusesource.ide.camel.editor.utils.MavenUtils;
 import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.jboss.tools.fuse.transformation.core.MappingOperation;
 import org.jboss.tools.fuse.transformation.editor.internal.MappingDetailViewer;
 import org.jboss.tools.fuse.transformation.editor.internal.MappingsViewer;
@@ -99,7 +99,7 @@ public class TransformationEditor extends EditorPart implements ISaveablePart2, 
     TransformationManager manager;
     URLClassLoader loader;
     File camelConfigFile;
-    CamelModelElement camelEndpoint;
+    AbstractCamelModelElement camelEndpoint;
 
     MappingsViewer mappingsViewer;
     Text helpText;

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/wizards/OtherPage.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/wizards/OtherPage.java
@@ -62,7 +62,7 @@ import org.eclipse.swt.widgets.Text;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.SelectionDialog;
 import org.eclipse.ui.progress.UIJob;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.jboss.tools.fuse.transformation.core.camel.CamelConfigBuilder;
 import org.jboss.tools.fuse.transformation.core.model.ModelBuilder;
 import org.jboss.tools.fuse.transformation.editor.Activator;
@@ -272,9 +272,9 @@ public class OtherPage extends XformWizardPage implements TransformationTypePage
         CamelConfigBuilder configBuilder = CamelConfigurationHelper.getConfigBuilder(camelIFile.getRawLocation().toFile());
 
         if (configBuilder != null) {
-            Collection<CamelModelElement> dataFormats = configBuilder.getDataFormats();
-            for (Iterator<CamelModelElement> iterator = dataFormats.iterator(); iterator.hasNext();) {
-            	CamelModelElement df = iterator.next();
+            Collection<AbstractCamelModelElement> dataFormats = configBuilder.getDataFormats();
+            for (Iterator<AbstractCamelModelElement> iterator = dataFormats.iterator(); iterator.hasNext();) {
+            	AbstractCamelModelElement df = iterator.next();
                 if (df.getId() != null) {
                     dfList.add(df.getId());
                 }

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/wizards/NewTransformationWizard.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/wizards/NewTransformationWizard.java
@@ -50,7 +50,7 @@ import org.eclipse.ui.part.FileEditorInput;
 import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.jboss.tools.fuse.transformation.core.MapperConfiguration;
 import org.jboss.tools.fuse.transformation.core.camel.CamelConfigBuilder;
 import org.jboss.tools.fuse.transformation.core.camel.CamelConfigBuilder.MarshalType;
@@ -85,11 +85,11 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
     private static final String OBJECT_FACTORY_NAME = "ObjectFactory";
 
     private Model uiModel = new Model();
-    private CamelModelElement sourceFormat;
-    private CamelModelElement targetFormat;
-    private CamelModelElement endpoint;
+    private AbstractCamelModelElement sourceFormat;
+    private AbstractCamelModelElement targetFormat;
+    private AbstractCamelModelElement endpoint;
     private boolean saveCamelConfig = true;
-    private CamelModelElement routeEndpoint;
+    private AbstractCamelModelElement routeEndpoint;
 
     public StartPage start;
     public JavaPage javaSource;
@@ -216,7 +216,7 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
         return false;
     }
 
-    public CamelModelElement getRouteEndpoint() {
+    public AbstractCamelModelElement getRouteEndpoint() {
         return routeEndpoint;
     }
 
@@ -501,15 +501,15 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
         this.saveCamelConfig = saveCamelConfig;
     }
 
-    public CamelModelElement getSourceFormat() {
+    public AbstractCamelModelElement getSourceFormat() {
         return sourceFormat;
     }
 
-    public CamelModelElement getTargetFormat() {
+    public AbstractCamelModelElement getTargetFormat() {
         return targetFormat;
     }
 
-    public CamelModelElement getEndpoint() {
+    public AbstractCamelModelElement getEndpoint() {
         return endpoint;
     }
 
@@ -517,19 +517,19 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
         return uiModel;
     }
 
-    private void addCamelContextEndpoint(CamelContextElement context, CamelModelElement endpoint) {
-        Map<String, CamelModelElement> endpoints = context.getEndpointDefinitions();
+    private void addCamelContextEndpoint(CamelContextElement context, AbstractCamelModelElement endpoint) {
+        Map<String, AbstractCamelModelElement> endpoints = context.getEndpointDefinitions();
         if (endpoints == null) {
-            endpoints = new HashMap<String, CamelModelElement>();
+            endpoints = new HashMap<String, AbstractCamelModelElement>();
             context.setEndpointDefinitions(endpoints);
         }
         endpoints.put(endpoint.getId(), endpoint);
     }
 
-    private void addDataFormat(CamelContextElement context, CamelModelElement dataFormat) {
-    	Map<String, CamelModelElement> dataFormats = context.getDataformats();
+    private void addDataFormat(CamelContextElement context, AbstractCamelModelElement dataFormat) {
+    	Map<String, AbstractCamelModelElement> dataFormats = context.getDataformats();
         if (dataFormats == null) {
-        	dataFormats = new HashMap<String, CamelModelElement>();
+        	dataFormats = new HashMap<String, AbstractCamelModelElement>();
             context.setDataformats(dataFormats);
         }
         dataFormats.put(dataFormat.getId(), dataFormat);
@@ -554,7 +554,7 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
         }
     }
 
-    private void addDataFormatDefinitionDependency(CamelModelElement dataFormat) {
+    private void addDataFormatDefinitionDependency(AbstractCamelModelElement dataFormat) {
         Dependency dep = null;
         String camelVersion = CamelUtils.getCurrentProjectCamelVersion();
         if (dataFormat != null && dataFormat.getNodeTypeId() != null) {

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/extensions/DataMapperEndpointFigureFeature.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/extensions/DataMapperEndpointFigureFeature.java
@@ -25,7 +25,7 @@ import org.eclipse.swt.widgets.Display;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.jboss.tools.fuse.transformation.editor.Activator;
 import org.jboss.tools.fuse.transformation.editor.internal.util.JavaUtil;
 import org.jboss.tools.fuse.transformation.editor.wizards.NewTransformationWizard;
@@ -61,7 +61,7 @@ public class DataMapperEndpointFigureFeature extends CreateEndpointFigureFeature
      * @see org.fusesource.ide.camel.editor.features.create.ext.CreateEndpointFigureFeature#createNode(org.fusesource.ide.camel.model.service.core.model.CamelModelElement, boolean)
      */
     @Override
-    protected CamelModelElement createNode(CamelModelElement parent, boolean createDOMNode) {
+    protected AbstractCamelModelElement createNode(AbstractCamelModelElement parent, boolean createDOMNode) {
         // Launch the New Transformation wizard
         NewTransformationWizard wizard = new NewTransformationWizard();
         wizard.setNeedsProgressMonitor(true);
@@ -80,7 +80,7 @@ public class DataMapperEndpointFigureFeature extends CreateEndpointFigureFeature
 
         WizardDialog dialog = new WizardDialog(Display.getCurrent().getActiveShell(), wizard);
         int status = dialog.open();
-        CamelModelElement ep = (status == IStatus.OK) ? wizard.getRouteEndpoint() : null;
+        AbstractCamelModelElement ep = (status == IStatus.OK) ? wizard.getRouteEndpoint() : null;
         if (ep != null && getEip() != null) {
         	CamelDesignEditor editor = (CamelDesignEditor)getDiagramBehavior().getDiagramContainer();
         	if (editor.getModel() != null) { 

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/extensions/TransformationDblClickHandler.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/extensions/TransformationDblClickHandler.java
@@ -23,7 +23,7 @@ import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.FileEditorInput;
 import org.fusesource.ide.camel.editor.provider.ext.ICustomDblClickHandler;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.foundation.ui.util.DialogUtils;
 import org.jboss.tools.fuse.transformation.core.camel.EndpointHelper;
 import org.jboss.tools.fuse.transformation.editor.Activator;
@@ -43,7 +43,7 @@ public class TransformationDblClickHandler implements ICustomDblClickHandler {
 	 * @see org.fusesource.ide.camel.editor.provider.ext.ICustomDblClickHandler#canHandle(org.fusesource.ide.camel.model.service.core.model.CamelModelElement)
 	 */
 	@Override
-	public boolean canHandle(CamelModelElement clickedNode) {
+	public boolean canHandle(AbstractCamelModelElement clickedNode) {
 		if (clickedNode.isEndpointElement()) {
 			String uri = (String) clickedNode.getParameter("uri");
 			if (uri != null && uri.trim().length()>0 && uri.trim().toLowerCase().startsWith("ref:")) {
@@ -87,7 +87,7 @@ public class TransformationDblClickHandler implements ICustomDblClickHandler {
 	 * @see org.fusesource.ide.camel.editor.provider.ext.ICustomDblClickHandler#handleDoubleClick(org.fusesource.ide.camel.model.service.core.model.CamelModelElement)
 	 */
 	@Override
-	public void handleDoubleClick(CamelModelElement clickedNode) {
+	public void handleDoubleClick(AbstractCamelModelElement clickedNode) {
 		if (clickedNode.isEndpointElement()) {
 			String id = ((String) clickedNode.getParameter("uri")).substring("ref:".length());
 			if (id != null) {

--- a/transformation/tests/org.jboss.tools.fuse.transformation.core.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/core/camel/CamelConfigBuilderIT.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.core.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/core/camel/CamelConfigBuilderIT.java
@@ -26,7 +26,7 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
 import org.assertj.core.api.Assertions;
-import org.fusesource.ide.camel.model.service.core.model.CamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.jboss.tools.fuse.transformation.core.TransformType;
 import org.jboss.tools.fuse.transformation.core.camel.CamelConfigBuilder;
 import org.jboss.tools.fuse.transformation.core.camel.CamelConfigBuilder.MarshalType;
@@ -59,11 +59,11 @@ public class CamelConfigBuilderIT {
 		// Document xmlJsonDoc = loadDocument(XML_JSON);
 		CamelConfigBuilder config = new CamelConfigBuilder(getFile(NEW_CONFIG));
 		config.getModel().getCamelContext().setId("test-defined-id");
-		CamelModelElement sourceFormat = config.createDataFormat(
+		AbstractCamelModelElement sourceFormat = config.createDataFormat(
                 TransformType.XML, "xml.ABCOrder", MarshalType.UNMARSHALLER);
-		CamelModelElement targetFormat = config.createDataFormat(
+		AbstractCamelModelElement targetFormat = config.createDataFormat(
                 TransformType.JSON, "json.XYZOrder", MarshalType.MARSHALLER);
-		CamelModelElement endpoint = config.createEndpoint("xml2json", 
+		AbstractCamelModelElement endpoint = config.createEndpoint("xml2json", 
                 DozerMapperConfiguration.DEFAULT_DOZER_CONFIG, 
                 "xml.ABCOrder", 
                 "json.XYZOrder",


### PR DESCRIPTION
Details property section

Introduced an AbstractCamel in order to provide a more modular code. (which introduced most of the file changed)
we also avoid to trigger showing it when Connection and CamelFile are
selected