### PR TITLE
FUSETOOLS-1562 - Use m2e Maven dependencies

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelGlobalConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelGlobalConfigEditor.java
@@ -551,7 +551,7 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 						List<Dependency> deps = item.getContributor().getElementDependencies();
 						if (deps != null && deps.isEmpty() == false) {
 							try {
-								MavenUtils.updateMavenDependencies(deps);
+								new MavenUtils().updateMavenDependencies(deps);
 							} catch (CoreException ex) {
 								CamelEditorUIActivator.pluginLog().logError("Unable to update pom dependencies for element " + item.getName(), ex);
 							}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateFigureFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/ext/CreateFigureFeature.java
@@ -261,7 +261,7 @@ public class CreateFigureFeature extends AbstractCreateFeature implements Palett
      * and inserts it into the pom.xml if needed
      */
     public void updateMavenDependencies(List<Dependency> compDeps) throws CoreException {
-    	MavenUtils.updateMavenDependencies(compDeps);
+		new MavenUtils().updateMavenDependencies(compDeps);
     }
     
 	/**

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/MavenUtils.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/MavenUtils.java
@@ -29,7 +29,11 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.core.runtime.Path;
 import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.internal.IMavenConstants;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.m2e.core.project.IMavenProjectRegistry;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
 
@@ -42,12 +46,11 @@ public class MavenUtils {
 	private static final String CAMEL_CORE_ARTIFACT_ID = "camel-core";
 	private static final String SCOPE_PROVIDED = "provided";
 	
-	
 	/**
      * checks if we need to add a maven dependency for the chosen component
      * and inserts it into the pom.xml if needed
      */
-    public static void updateMavenDependencies(List<org.fusesource.ide.camel.model.service.core.catalog.Dependency> compDeps) throws CoreException {
+	public void updateMavenDependencies(List<org.fusesource.ide.camel.model.service.core.catalog.Dependency> compDeps) throws CoreException {
         CamelDesignEditor editor = CamelUtils.getDiagramEditor();
         if (editor == null) {
             CamelEditorUIActivator.pluginLog().logError("Unable to add component dependencies because Editor instance can't be determined.");
@@ -60,14 +63,22 @@ public class MavenUtils {
             return;
         }
         
-        IPath pomPathValue = project.getProject().getRawLocation() != null ? project.getProject().getRawLocation().append("pom.xml") : ResourcesPlugin.getWorkspace().getRoot().getLocation().append(project.getFullPath().append("pom.xml"));
-        String pomPath = pomPathValue.toOSString();
-        final File pomFile = new File(pomPath);
-        final Model model = MavenPlugin.getMaven().readModel(pomFile);
+        updateMavenDependencies(compDeps, project);
+    }
+
+	/**
+	 * @param compDeps
+	 * @param project
+	 * @throws CoreException
+	 */
+	protected void updateMavenDependencies(List<org.fusesource.ide.camel.model.service.core.catalog.Dependency> compDeps, IProject project) throws CoreException {
+		final File pomFile = getPomFile(project);
+
+		final Model model = readMavenModel(pomFile);
+		List<Dependency> deps = getDependencies(project, model);
 
         // then check if component dependency is already a dep
         ArrayList<org.fusesource.ide.camel.model.service.core.catalog.Dependency> missingDeps = new ArrayList<org.fusesource.ide.camel.model.service.core.catalog.Dependency>();
-        List<Dependency> deps = model.getDependencies();
         String scope = null;
         for (org.fusesource.ide.camel.model.service.core.catalog.Dependency conDep : compDeps) {
             boolean found = false;
@@ -75,14 +86,14 @@ public class MavenUtils {
             	if (scope == null && 
             		pomDep.getGroupId().equalsIgnoreCase(CAMEL_GROUP_ID) && 
             		pomDep.getArtifactId().equalsIgnoreCase(CAMEL_CORE_ARTIFACT_ID)) {
-            		if (pomDep.getScope() != null && pomDep.getScope().equalsIgnoreCase(SCOPE_PROVIDED)) {
+					if (SCOPE_PROVIDED.equalsIgnoreCase(pomDep.getScope())) {
             			scope = pomDep.getScope();
             		}
             	}
                 if (pomDep.getGroupId().equalsIgnoreCase(conDep.getGroupId()) &&
                     pomDep.getArtifactId().equalsIgnoreCase(conDep.getArtifactId())) {
                     // check for correct version
-                    if (pomDep.getVersion().equalsIgnoreCase(conDep.getVersion()) == false) {
+					if (pomDep.getVersion() == null || !pomDep.getVersion().equalsIgnoreCase(conDep.getVersion())) {
                         // not the correct version - change it to fit
                         pomDep.setVersion(conDep.getVersion());
                     }
@@ -95,7 +106,66 @@ public class MavenUtils {
             }
         }
 
-        for (org.fusesource.ide.camel.model.service.core.catalog.Dependency missDep : missingDeps) {
+        addDependency(model, missingDeps, scope);
+        
+        if (missingDeps.size()>0) {
+            writeNewPomFile(project, pomFile, model);
+        }
+	}
+
+	/**
+	 * @param pomFile
+	 * @return
+	 * @throws CoreException
+	 */
+	Model readMavenModel(final File pomFile) throws CoreException {
+		return MavenPlugin.getMaven().readModel(pomFile);
+	}
+
+	/**
+	 * @param project
+	 * @return
+	 */
+	File getPomFile(IProject project) {
+		IPath pomPathValue = project.getProject().getRawLocation() != null ? project.getProject().getRawLocation().append("pom.xml") : ResourcesPlugin.getWorkspace().getRoot().getLocation().append(project.getFullPath().append("pom.xml"));
+        String pomPath = pomPathValue.toOSString();
+		return new File(pomPath);
+	}
+
+	/**
+	 * @param project
+	 * @param pomFile
+	 * @param model
+	 */
+	void writeNewPomFile(IProject project, final File pomFile, final Model model) {
+		OutputStream os = null;
+		try {
+		    os = new BufferedOutputStream(new FileOutputStream(pomFile));
+		    MavenPlugin.getMaven().writeModel(model, os);
+			IFile pomIFile2 = project.getProject().getFile("pom.xml");
+			if (pomIFile2 != null) {
+				pomIFile2.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+		    }
+		} catch (Exception ex) {
+		    CamelEditorUIActivator.pluginLog().logError(ex);
+		} finally {
+		    try {
+		        if (os != null) {
+		            os.close();
+		        }
+		    } catch (IOException e) {
+		    	CamelEditorUIActivator.pluginLog().logError(e);
+		    }
+		}
+	}
+
+	/**
+	 * @param model
+	 * @param missingDeps
+	 * @param scope
+	 */
+	void addDependency(final Model model, List<org.fusesource.ide.camel.model.service.core.catalog.Dependency> missingDeps, String scope) {
+		for (org.fusesource.ide.camel.model.service.core.catalog.Dependency missDep : missingDeps) {
             Dependency dep = new Dependency();
             dep.setGroupId(missDep.getGroupId());
             dep.setArtifactId(missDep.getArtifactId());
@@ -105,29 +175,39 @@ public class MavenUtils {
             }
             model.addDependency(dep);
         }
-        
-        if (missingDeps.size()>0) {
-            OutputStream os = null;
-            try {
-                os = new BufferedOutputStream(new FileOutputStream(pomFile));
-                MavenPlugin.getMaven().writeModel(model, os);
-                IFile pomIFile = project.getProject().getFile("pom.xml");
-                if (pomIFile != null){
-                    pomIFile.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
-                }
-            } catch (Exception ex) {
-                CamelEditorUIActivator.pluginLog().logError(ex);
-            } finally {
-                try {
-                    if (os != null) {
-                        os.close();
-                    }
-                } catch (IOException e) {
-                	CamelEditorUIActivator.pluginLog().logError(e);
-                }
-            }
-        }
-    }
+	}
+
+	/**
+	 * @param project
+	 * @param model
+	 * @return
+	 */
+	private List<Dependency> getDependencies(IProject project, final Model model) {
+		IMavenProjectFacade projectFacade = getMavenProjectFacade(project);
+		List<Dependency> deps;
+		if (projectFacade != null) {
+			try {
+				deps = projectFacade.getMavenProject(new NullProgressMonitor()).getDependencies();
+			} catch (CoreException e) {
+				CamelEditorUIActivator.pluginLog().logError("Maven project has not been found (not imported?). Managed Dependencies won't be resolved.", e);
+				deps = model.getDependencies();
+			}
+		} else {
+			// In case the project was not imported in the workspace
+			deps = model.getDependencies();
+		}
+		return deps;
+	}
+
+	/**
+	 * @param project
+	 * @return
+	 */
+	IMavenProjectFacade getMavenProjectFacade(IProject project) {
+		final IMavenProjectRegistry projectRegistry = MavenPlugin.getMavenProjectRegistry();
+		final IFile pomIFile = project.getFile(new Path(IMavenConstants.POM_FILE_NAME));
+		return projectRegistry.create(pomIFile, false, new NullProgressMonitor());
+	}
     
     /**
      * adds a resource folder to the maven pom file if not yet there
@@ -137,8 +217,8 @@ public class MavenUtils {
      * @param resourceFolderName	the name of the new resource folder
      * @throws CoreException	on any errors
      */
-    public static void addResourceFolder(IProject project, File pomFile, String resourceFolderName) throws CoreException {
-    	final Model model = MavenPlugin.getMaven().readModel(pomFile);
+	public void addResourceFolder(IProject project, File pomFile, String resourceFolderName) throws CoreException {
+    	final Model model = readMavenModel(pomFile);
         List<Resource> resources = model.getBuild().getResources();
         
         boolean exists = false;

--- a/editor/tests/org.fusesource.ide.camel.editor.tests/src-test/java/org/fusesource/ide/camel/editor/utils/MavenUtilsTest.java
+++ b/editor/tests/org.fusesource.ide.camel.editor.tests/src-test/java/org/fusesource/ide/camel/editor/utils/MavenUtilsTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.camel.editor.utils;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.maven.model.Model;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MavenUtilsTest {
+
+	@Spy
+	private MavenUtils mavenUtils;
+	@Mock
+	private IProject project;
+	@Mock
+	private File pomFile;
+	@Mock(answer = Answers.RETURNS_DEEP_STUBS)
+	private IMavenProjectFacade mavenProjectFacade;
+
+	@Captor
+	private ArgumentCaptor<List<org.fusesource.ide.camel.model.service.core.catalog.Dependency>> captor;
+
+	@Before
+	public void setup() throws CoreException {
+		doReturn(pomFile).when(mavenUtils).getPomFile(project);
+		doNothing().when(mavenUtils).writeNewPomFile(eq(project), eq(pomFile), any(Model.class));
+	}
+
+	@Test
+	public void testUpdateMavenDependencyWithNullVersion() throws Exception {
+		doReturn(null).when(mavenUtils).getMavenProjectFacade(project);
+		final Model mavenModel = new Model();
+		final org.apache.maven.model.Dependency mavenDependency = new org.apache.maven.model.Dependency();
+		mavenDependency.setArtifactId("test-artifactID");
+		mavenDependency.setGroupId("test-groupID");
+		mavenModel.addDependency(mavenDependency);
+		doReturn(mavenModel).when(mavenUtils).readMavenModel(pomFile);
+
+		List<Dependency> compDeps = new ArrayList<>();
+		final Dependency dep = new Dependency();
+		dep.setArtifactId("test-artifactID");
+		dep.setGroupId("test-groupID");
+		dep.setVersion("test-version");
+		compDeps.add(dep);
+		mavenUtils.updateMavenDependencies(compDeps, project);
+		assertThat(mavenDependency.getVersion()).isEqualTo("test-version");
+	}
+
+	@Test
+	public void testUpdateMavenDependencyWithManagedDependency() throws Exception {
+		// so retrieved from the MavenprojectFacade
+		final ArrayList<org.apache.maven.model.Dependency> m2eDependencies = new ArrayList<org.apache.maven.model.Dependency>();
+		org.apache.maven.model.Dependency m2eDependency = new org.apache.maven.model.Dependency();
+		m2eDependency.setArtifactId("test-artifactID");
+		m2eDependency.setGroupId("test-groupID");
+		m2eDependency.setVersion("differetnversion-test");
+		m2eDependencies.add(m2eDependency);
+		when(mavenProjectFacade.getMavenProject(Mockito.any(NullProgressMonitor.class)).getDependencies()).thenReturn(m2eDependencies);
+		doReturn(mavenProjectFacade).when(mavenUtils).getMavenProjectFacade(project);
+		final Model mavenModel = new Model();
+		final org.apache.maven.model.Dependency mavenDependency = new org.apache.maven.model.Dependency();
+		mavenDependency.setArtifactId("test-artifactID");
+		mavenDependency.setGroupId("test-groupID");
+		mavenModel.addDependency(mavenDependency);
+		doReturn(mavenModel).when(mavenUtils).readMavenModel(pomFile);
+
+		List<Dependency> compDeps = new ArrayList<>();
+		final Dependency dep = new Dependency();
+		dep.setArtifactId("test-artifactID");
+		dep.setGroupId("test-groupID");
+		dep.setVersion("test-version");
+		compDeps.add(dep);
+		mavenUtils.updateMavenDependencies(compDeps, project);
+		assertThat(m2eDependency.getVersion()).isEqualTo("test-version");
+	}
+
+	@Test
+	public void testUpdateMavenDependencyForMissingDependency() throws Exception {
+		// so retrieved from the MavenprojectFacade
+		final ArrayList<org.apache.maven.model.Dependency> m2eDependencies = new ArrayList<org.apache.maven.model.Dependency>();
+		when(mavenProjectFacade.getMavenProject(Mockito.any(NullProgressMonitor.class)).getDependencies()).thenReturn(m2eDependencies);
+		doReturn(mavenProjectFacade).when(mavenUtils).getMavenProjectFacade(project);
+		final Model mavenModel = new Model();
+		final org.apache.maven.model.Dependency mavenDependency = new org.apache.maven.model.Dependency();
+		mavenDependency.setArtifactId("test-artifactID");
+		mavenDependency.setGroupId("test-groupID");
+		mavenModel.addDependency(mavenDependency);
+		doReturn(mavenModel).when(mavenUtils).readMavenModel(pomFile);
+
+		List<Dependency> compDeps = new ArrayList<>();
+		final Dependency dep = new Dependency();
+		dep.setArtifactId("test-artifactID");
+		dep.setGroupId("test-groupID");
+		dep.setVersion("test-version");
+		compDeps.add(dep);
+		mavenUtils.updateMavenDependencies(compDeps, project);
+		verify(mavenUtils).addDependency(eq(mavenModel), captor.capture(), eq((String) null));
+		assertThat(captor.getValue().get(0).getArtifactId()).isEqualTo("test-artifactID");
+	}
+}

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/TransformationEditor.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/TransformationEditor.java
@@ -359,7 +359,7 @@ public class TransformationEditor extends EditorPart implements ISaveablePart2, 
             
             // Ensure Maven will compile transformations folder
             File pomFile = manager.project().getLocation().append("pom.xml").toFile();
-            MavenUtils.addResourceFolder(manager.project(), pomFile, Util.TRANSFORMATIONS_FOLDER);
+			new MavenUtils().addResourceFolder(manager.project(), pomFile, Util.TRANSFORMATIONS_FOLDER);
             
             // Ensure Java project source classpath entry exists for transformations folder
             boolean exists = false;


### PR DESCRIPTION
using m2e Maven dependencies on a pom provides support for Managed
Dependencies version

/!\ in case the project is not imported in the workspace, if the version comes from a parent pom, the current version will be added (but at least we won't have anymore a NPE and user really should to import its projects)