### PR TITLE
FUSETOOLS-1706 - Set underlying metamodel when creating global endpoint

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelGlobalConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelGlobalConfigEditor.java
@@ -57,6 +57,8 @@ import org.fusesource.ide.camel.editor.internal.UIMessages;
 import org.fusesource.ide.camel.editor.provider.ext.GlobalConfigurationTypeWizard;
 import org.fusesource.ide.camel.editor.provider.ext.ICustomGlobalConfigElementContribution;
 import org.fusesource.ide.camel.editor.utils.MavenUtils;
+import org.fusesource.ide.camel.model.service.core.catalog.CamelModel;
+import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
 import org.fusesource.ide.camel.model.service.core.catalog.Dependency;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelBasicModelElement;
@@ -573,6 +575,8 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 		AbstractCamelModelElement elemEP = new CamelEndpoint(newXMLNode.getAttribute("uri"));
 		elemEP.setXmlNode(newXMLNode);
 		elemEP.setId(newXMLNode.getAttribute("id"));
+		final CamelModel camelModel = CamelModelFactory.getModelForVersion(CamelModelFactory.getCamelVersion(cf.getResource().getProject()));
+		elemEP.setUnderlyingMetaModelObject(camelModel.getEipModel().getEIPByName("to"));
 		final String description = newXMLNode.getAttribute("description");
 		if (description != null && !description.isEmpty()) {
 			elemEP.setDescription(description);


### PR DESCRIPTION
It avoids having to switch between to reload the model before the
Properties view are available

Is it the right way to do?
I didn't found a buld for the endpoint. The only one available is in transformation and it adds the endpoint with an EIP "from" although when reloaded the model was "to"
But I am even  not sure of the from/to, maybe it should stay "endpoint" and I need to modify the AdvancedpropertiesFilter