### PR TITLE
FUSETOOLS-1767 - Call layout only at the end of the import

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/DiagramOperations.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/DiagramOperations.java
@@ -17,13 +17,14 @@ import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.emf.transaction.util.TransactionUtil;
 import org.eclipse.graphiti.dt.IDiagramTypeProvider;
+import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.platform.IDiagramBehavior;
 import org.eclipse.graphiti.ui.services.GraphitiUi;
 import org.eclipse.swt.widgets.Display;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
-import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 
 /**
  * @author lhein
@@ -33,7 +34,14 @@ public class DiagramOperations {
 	public static LayoutCommand layoutDiagram(CamelDesignEditor designEditor) {
 		if (designEditor == null) return null;
 		TransactionalEditingDomain editingDomain = createEditingDomain(designEditor);
-		LayoutCommand operation = new LayoutCommand(designEditor, editingDomain);
+		LayoutCommand operation = new LayoutCommand(designEditor.getFeatureProvider(), designEditor.getDiagramTypeProvider().getDiagram(),
+				designEditor.getModel().getCamelContext(), editingDomain);
+		execute(editingDomain, operation, false);
+		return operation;
+	}
+
+	public static LayoutCommand layoutDiagram(TransactionalEditingDomain editingDomain, IFeatureProvider featureProvider, Diagram diagram, AbstractCamelModelElement container) {
+		LayoutCommand operation = new LayoutCommand(featureProvider, diagram, container, editingDomain);
 		execute(editingDomain, operation, false);
 		return operation;
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/ImportCamelContextElementsCommand.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/ImportCamelContextElementsCommand.java
@@ -10,28 +10,21 @@
  ******************************************************************************/ 
 package org.fusesource.ide.camel.editor.commands;
 
-import java.util.ArrayList;
-
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.transaction.RecordingCommand;
 import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.graphiti.dt.IDiagramTypeProvider;
 import org.eclipse.graphiti.features.IFeatureProvider;
-import org.eclipse.graphiti.features.context.impl.CustomContext;
-import org.eclipse.graphiti.features.custom.ICustomFeature;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
-import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.services.Graphiti;
 import org.eclipse.graphiti.ui.services.GraphitiUi;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
-import org.fusesource.ide.camel.editor.features.custom.LayoutDiagramFeature;
 import org.fusesource.ide.camel.editor.internal.CamelDiagramLoader;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
-import org.fusesource.ide.camel.editor.utils.NodeUtils;
+import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelContextElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
-import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 
 /**
  * @author lhein
@@ -112,26 +105,10 @@ public class ImportCamelContextElementsCommand extends RecordingCommand {
 			CamelDiagramLoader diagramReader = new CamelDiagramLoader(diagram, featureProvider);
 			try {
 				context = (CamelContextElement)camelContextFile.getChildElements().get(0);
-				diagramReader.loadModel(this.container != null && this.container instanceof CamelFile == false ? this.container : context);
+				diagramReader.loadModel(editingDomain, this.container != null && this.container instanceof CamelFile == false ? this.container : context);
 			} catch (Exception e) {
 				CamelEditorUIActivator.pluginLog().logError("Failed to load model: " + e, e);
 			}
-			
-	        ArrayList<PictogramElement> containers = new ArrayList<PictogramElement>();
-	        containers.add(diagram);
-	        NodeUtils.getAllContainers(featureProvider, container != null ? container : designEditor.getModel().getCamelContext(), containers);
-	        for (int i=0; i<containers.size(); i++) {
-		        for (PictogramElement pe : containers) {
-		        	CustomContext cc = new CustomContext(new PictogramElement[] {pe});
-		        	ICustomFeature[] cfs = featureProvider.getCustomFeatures(null);
-		        	for (ICustomFeature cf : cfs) {
-		        		if (cf instanceof LayoutDiagramFeature) {
-		        			cf.execute(cc);		
-		        			break;
-		        		}
-		        	}        	
-		        }
-	        }
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		} finally {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/add/AddFlowFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/add/AddFlowFeature.java
@@ -37,6 +37,8 @@ import org.fusesource.ide.preferences.PreferencesConstants;
  */
 public class AddFlowFeature extends AbstractAddFeature {
 
+	public static final String DEACTIVATE_LAYOUT = "deactivateLayout";
+
 	public AddFlowFeature(IFeatureProvider fp) {
 		super(fp);
 	}
@@ -87,11 +89,13 @@ public class AddFlowFeature extends AbstractAddFeature {
 //		text.setValue(flow.getName());
 		
 		// add static graphical decorators (composition and navigable)
-		ConnectionDecorator cd;
-		cd = peCreateService.createConnectionDecorator(connection, false, 1.0, true);
+		ConnectionDecorator cd = peCreateService.createConnectionDecorator(connection, false, 1.0, true);
 		createArrow(cd);
 		
-		DiagramOperations.layoutDiagram(CamelUtils.getDiagramEditor());
+		final Object deactivateLayout = context.getProperty(DEACTIVATE_LAYOUT);
+		if (!Boolean.TRUE.equals(deactivateLayout)) {
+			DiagramOperations.layoutDiagram(CamelUtils.getDiagramEditor());
+		}
 		
 		return connection;
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/add/AddNodeFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/add/AddNodeFeature.java
@@ -30,6 +30,8 @@ import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelEleme
  */
 public class AddNodeFeature extends AbstractAddShapeFeature {
 
+	public static final String DEACTIVATE_LAYOUT = "deactivateLayout";
+
 	/**
 	 * 
 	 * @param fp
@@ -48,9 +50,10 @@ public class AddNodeFeature extends AbstractAddShapeFeature {
 		if (newObject instanceof AbstractCamelModelElement) {
 			// check if user wants to add to a diagram
 			if (context.getTargetContainer() instanceof Diagram) {
-                return ((AbstractCamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("route") ||
-                		((AbstractCamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("rest") ||
-                		((AbstractCamelModelElement) newObject).getNodeTypeId().equalsIgnoreCase("restConfiguration");
+                final String nodeTypeId = ((AbstractCamelModelElement) newObject).getNodeTypeId();
+				return nodeTypeId.equalsIgnoreCase("route") ||
+                		nodeTypeId.equalsIgnoreCase("rest") ||
+                		nodeTypeId.equalsIgnoreCase("restConfiguration");
             } else if (getBusinessObjectForPictogramElement(context.getTargetContainer()) instanceof AbstractCamelModelElement) {
             	AbstractCamelModelElement container =  (AbstractCamelModelElement)getBusinessObjectForPictogramElement(context.getTargetContainer());
             	AbstractCamelModelElement child = (AbstractCamelModelElement)newObject;
@@ -82,14 +85,17 @@ public class AddNodeFeature extends AbstractAddShapeFeature {
 		// call the layout feature
 		layoutPictogramElement(containerShape);
 		
-		Object o_editor = getFeatureProvider().getDiagramTypeProvider().getDiagramBehavior().getDiagramContainer();
-		CamelDesignEditor editor = null;
-		if (o_editor == null || o_editor instanceof DiagramEditorDummy) {
-			editor = CamelUtils.getDiagramEditor();
-		} else {
-			editor = (CamelDesignEditor)o_editor;
+		final Object deactivateLayout = context.getProperty(DEACTIVATE_LAYOUT);
+		if (!Boolean.TRUE.equals(deactivateLayout)) {
+			Object o_editor = getFeatureProvider().getDiagramTypeProvider().getDiagramBehavior().getDiagramContainer();
+			CamelDesignEditor editor = null;
+			if (o_editor == null || o_editor instanceof DiagramEditorDummy) {
+				editor = CamelUtils.getDiagramEditor();
+			} else {
+				editor = (CamelDesignEditor) o_editor;
+			}
+			DiagramOperations.layoutDiagram(editor);
 		}
-		DiagramOperations.layoutDiagram(editor);
 
 		return containerShape;
 	}

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/CreateFlowFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/create/CreateFlowFeature.java
@@ -16,10 +16,11 @@ import org.eclipse.graphiti.features.context.impl.AddConnectionContext;
 import org.eclipse.graphiti.features.impl.AbstractCreateConnectionFeature;
 import org.eclipse.graphiti.mm.pictograms.Anchor;
 import org.eclipse.graphiti.mm.pictograms.Connection;
+import org.fusesource.ide.camel.editor.features.add.AddFlowFeature;
 import org.fusesource.ide.camel.editor.provider.ImageProvider;
 import org.fusesource.ide.camel.editor.provider.ext.PaletteCategoryItemProvider;
-import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
+import org.fusesource.ide.camel.model.service.core.model.CamelElementConnection;
 
 /**
  * @author lhein
@@ -99,6 +100,7 @@ public class CreateFlowFeature extends AbstractCreateConnectionFeature implement
 			// add connection for business object
 			AddConnectionContext addContext = new AddConnectionContext(context.getSourceAnchor(), context.getTargetAnchor());
 			addContext.setNewObject(eReference);
+			addContext.putProperty(AddFlowFeature.DEACTIVATE_LAYOUT, context.getProperty(AddFlowFeature.DEACTIVATE_LAYOUT));
 			newConnection = (Connection) getFeatureProvider().addIfPossible(addContext);
 		}
 

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelDiagramLoader.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelDiagramLoader.java
@@ -16,6 +16,7 @@ import java.util.List;
 
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.transaction.TransactionalEditingDomain;
 import org.eclipse.graphiti.features.IAddFeature;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.impl.AddContext;
@@ -29,7 +30,6 @@ import org.fusesource.ide.camel.editor.commands.DiagramOperations;
 import org.fusesource.ide.camel.editor.features.add.AddFlowFeature;
 import org.fusesource.ide.camel.editor.features.add.AddNodeFeature;
 import org.fusesource.ide.camel.editor.features.create.CreateFlowFeature;
-import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.editor.utils.FigureUIFactory;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
@@ -64,7 +64,7 @@ public class CamelDiagramLoader {
 	 * 
 	 * @param container
 	 */
-	public void loadModel(AbstractCamelModelElement container) {
+	public void loadModel(TransactionalEditingDomain editingDomain, AbstractCamelModelElement container) {
 		if (container == null) {
 			return;
 		}
@@ -82,7 +82,7 @@ public class CamelDiagramLoader {
 			}
 			lastElem = node;
 		}
-		DiagramOperations.layoutDiagram(CamelUtils.getDiagramEditor());
+		DiagramOperations.layoutDiagram(editingDomain, featureProvider, diagram, container);
 	}
 
 	private int addProcessor(AbstractCamelModelElement lastElement, AbstractCamelModelElement node, int x, int y, List<AbstractCamelModelElement> processedNodes, ContainerShape container) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelDiagramLoader.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/internal/CamelDiagramLoader.java
@@ -25,7 +25,11 @@ import org.eclipse.graphiti.mm.pictograms.AnchorContainer;
 import org.eclipse.graphiti.mm.pictograms.ContainerShape;
 import org.eclipse.graphiti.mm.pictograms.Diagram;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
+import org.fusesource.ide.camel.editor.commands.DiagramOperations;
+import org.fusesource.ide.camel.editor.features.add.AddFlowFeature;
+import org.fusesource.ide.camel.editor.features.add.AddNodeFeature;
 import org.fusesource.ide.camel.editor.features.create.CreateFlowFeature;
+import org.fusesource.ide.camel.editor.utils.CamelUtils;
 import org.fusesource.ide.camel.editor.utils.FigureUIFactory;
 import org.fusesource.ide.camel.model.service.core.model.AbstractCamelModelElement;
 import org.fusesource.ide.camel.model.service.core.model.CamelRouteElement;
@@ -78,6 +82,7 @@ public class CamelDiagramLoader {
 			}
 			lastElem = node;
 		}
+		DiagramOperations.layoutDiagram(CamelUtils.getDiagramEditor());
 	}
 
 	private int addProcessor(AbstractCamelModelElement lastElement, AbstractCamelModelElement node, int x, int y, List<AbstractCamelModelElement> processedNodes, ContainerShape container) {
@@ -87,6 +92,7 @@ public class CamelDiagramLoader {
 		addContext.setTargetContainer(container);
 		addContext.setX(x);
 		addContext.setY(y);
+		addContext.putProperty(AddNodeFeature.DEACTIVATE_LAYOUT, true);
 
 		int retVal = this.orientation == PositionConstants.EAST ? x : y;
 		
@@ -117,6 +123,7 @@ public class CamelDiagramLoader {
 				}
 				connectContext.setSourcePictogramElement(srcState);
 				connectContext.setTargetPictogramElement(destState);
+				connectContext.putProperty(AddFlowFeature.DEACTIVATE_LAYOUT, true);
 				Anchor srcAnchor = getAnchor(srcState);
 				Anchor destAnchor = getAnchor(destState);
 				if (srcAnchor != null && destAnchor != null) {

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/NodeUtils.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/utils/NodeUtils.java
@@ -11,7 +11,7 @@
 
 package org.fusesource.ide.camel.editor.utils;
 
-import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.gef.editparts.AbstractEditPart;
@@ -93,7 +93,7 @@ public class NodeUtils {
 	 * @param context
 	 * @param pes
 	 */
-    public static void getAllContainers(IFeatureProvider fp, AbstractCamelModelElement context, ArrayList<PictogramElement> pes) {
+	public static void getAllContainers(IFeatureProvider fp, AbstractCamelModelElement context, List<PictogramElement> pes) {
 		if (context instanceof CamelRouteElement) {
 			pes.add(fp.getDiagramTypeProvider().getFeatureProvider().getPictogramElementForBusinessObject(context));
 		}


### PR DESCRIPTION
We are doing a batch import of every elements of the model. Layouting is
needed only at the end of this import.