### PR TITLE
FUSETOOLS-1655 - Include tests into update site

### DIFF
--- a/core/features/org.fusesource.ide.core.feature/feature.properties
+++ b/core/features/org.fusesource.ide.core.feature/feature.properties
@@ -23,6 +23,6 @@ providerName=JBoss by Red Hat
 # "description" property - description of the feature
 description=Provides core bundles used by the other features of JBoss Fuse Tooling. This includes Maven support, the documentation, preferences and more.
 copyright=JBoss, Home of Professional Open Source\nCopyright (c) Red Hat, Inc., and individual contributors as indicated\nby the @authors tag, \
-2006-2015. See the copyright.txt in the distribution\nfor a full listing of individual contributors.
+2006-2016. See the copyright.txt in the distribution\nfor a full listing of individual contributors.
 
 licenseURL=license.html

--- a/core/features/org.fusesource.ide.core.tests.feature/.project
+++ b/core/features/org.fusesource.ide.core.tests.feature/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.fusesource.ide.core.tests.feature</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/core/features/org.fusesource.ide.core.tests.feature/build.properties
+++ b/core/features/org.fusesource.ide.core.tests.feature/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/core/features/org.fusesource.ide.core.tests.feature/feature.xml
+++ b/core/features/org.fusesource.ide.core.tests.feature/feature.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.fusesource.ide.core.tests.feature"
+      label="JBoss Fuse Tooling Core Tests Feature"
+      version="8.0.0.qualifier"
+      provider-name="Red Hat"
+      license-feature="org.jboss.tools.foundation.license.feature">
+
+   <description url="http://tools.jboss.org/features/apachecamel.html">
+      This provides Core tests of Jboss Fuse Tooling. Including Utility plugin.
+   </description>
+
+   <copyright url="http://redhat.com/">
+      JBoss, Home of Professional Open Source\nCopyright (c) Red Hat, Inc., and individual contributors as indicated\nby the @authors tag, \
+2006-2016. See the copyright.txt in the distribution\nfor a full listing of individual contributors.
+   </copyright>
+
+   <license url="http://www.example.com/license">
+      [Enter License Description here.]
+   </license>
+
+   <requires>
+      <import plugin="org.assertj.core" version="2.1.0" match="greaterOrEqual"/>
+      <import plugin="org.junit" version="4.12.0" match="greaterOrEqual"/>
+      <import plugin="org.jboss.tools.locus.mockito" version="1.9.5" match="greaterOrEqual"/>
+      <import plugin="org.fusesource.ide.camel.model.service.v2_16_1" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.fusesource.ide.camel.model.service.core" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.11.1" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.resources"/>
+      <import plugin="org.eclipse.core.databinding.observable" version="1.5.0" match="greaterOrEqual"/>
+      <import plugin="org.fusesource.ide.foundation.core" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.fusesource.ide.foundation.ui" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.fusesource.ide.camel.model.service.v2_15_2" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.fusesource.ide.camel.validation" version="8.0.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.databinding" version="1.5.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.wst.validation"/>
+      <import plugin="org.eclipse.ui" version="3.107.0" match="greaterOrEqual"/>
+   </requires>
+
+   <plugin
+         id="org.fusesource.ide.camel.model.service.core.tests.integration"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.fusesource.ide.camel.model.tests"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.fusesource.ide.camel.tests.util"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.fusesource.ide.camel.validation.tests.integration"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/core/features/org.fusesource.ide.core.tests.feature/pom.xml
+++ b/core/features/org.fusesource.ide.core.tests.feature/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <groupId>org.fusesource.ide.core</groupId>
+    <artifactId>features</artifactId>
+    <version>8.0.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>org.fusesource.ide.core.tests.feature</artifactId>
+  <packaging>eclipse-feature</packaging>
+  <name>JBoss Fuse Tooling :: Core :: Features :: Core Tests Feature</name>
+</project>

--- a/core/features/pom.xml
+++ b/core/features/pom.xml
@@ -12,6 +12,7 @@
 	<packaging>pom</packaging>
 	<modules>
 		<module>org.fusesource.ide.core.feature</module>
+		<module>org.fusesource.ide.core.tests.feature</module>
 	</modules>
 
 </project>

--- a/site/category.xml
+++ b/site/category.xml
@@ -6,38 +6,39 @@
    <feature id="org.fusesource.ide.core.feature">
       <category name="AllFeatures"/>
    </feature>
+   <feature id="org.fusesource.ide.core.tests.feature">
+      <category name="AllTests"/>
+   </feature>
+      <feature id="org.fusesource.ide.core.tests.feature.source">
+      <category name="AllTestsSources"/>
+   </feature>
    <feature id="org.fusesource.ide.core.feature.source">
       <category name="AllSources"/>
    </feature>
-
    <feature id="org.fusesource.ide.camel.editor.feature">
       <category name="AllFeatures"/>
    </feature>
    <feature id="org.fusesource.ide.camel.editor.feature.source">
       <category name="AllSources"/>
    </feature>
-
    <feature id="org.fusesource.ide.jmx.feature">
       <category name="AllFeatures"/>
    </feature>
    <feature id="org.fusesource.ide.jmx.feature.source">
       <category name="AllSources"/>
    </feature>
-
    <feature id="org.fusesource.ide.server.extensions.feature">
       <category name="AllFeatures"/>
    </feature>
    <feature id="org.fusesource.ide.server.extensions.feature.source">
       <category name="AllSources"/>
    </feature>
-
    <feature id="org.jboss.tools.fuse.transformation.feature">
       <category name="AllFeatures"/>
    </feature>
    <feature id="org.jboss.tools.fuse.transformation.feature.source">
       <category name="AllSources"/>
    </feature>
-
    <category-def name="AllFeatures" label="JBoss Fuse Tooling Nightly Build Update Site">
       <description>
          JBoss Fuse Tooling Nightly Build Update Site: contains all features in this build.
@@ -46,6 +47,16 @@
    <category-def name="AllSources" label="JBoss Fuse Tooling Nightly Build Update Site">
       <description>
          JBoss Fuse Tooling Nightly Build Update Site: contains all source features in this build.
+      </description>
+   </category-def>
+   <category-def name="AllTests" label="JBoss Fuse Tooling Nightly Build Update Site">
+      <description>
+         JBoss Fuse Tooling Nightly Build Update Site: contains all tests features in this build.
+      </description>
+   </category-def>
+   <category-def name="AllTestsSources" label="JBoss Fuse Tooling Nightly Build Update Site">
+      <description>
+         JBoss Fuse Tooling Nightly Build Update Site: contains all source test features in this build.
       </description>
    </category-def>
 </site>


### PR DESCRIPTION
- create a feature for core tests
- the goal is to reuse rules in SAP Tooling project
- No unit tests due to limitation of fragment use
