### PR TITLE
FUSETOOLS-1827 - Support new Date format from JMX to display in Messages

### DIFF
--- a/jmx/plugins/org.fusesource.ide.jmx.commons/.settings/org.moreunit.prefs
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/.settings/org.moreunit.prefs
@@ -1,4 +1,4 @@
 eclipse.preferences.version=1
 org.moreunit.preferences.version=2
-org.moreunit.unitsourcefolder=org.fusesource.ide.jmx.commons\:src\:org.fusesource.ide.jmx.common.tests\:src-test
+org.moreunit.unitsourcefolder=org.fusesource.ide.jmx.commons\:src\:org.fusesource.ide.jmx.common.tests\:src/test/java
 org.moreunit.useprojectsettings=true

--- a/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/backlogtracermessage/BacklogTracerEventMessage.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/backlogtracermessage/BacklogTracerEventMessage.java
@@ -14,6 +14,7 @@ import java.util.Date;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import org.fusesource.ide.camel.model.service.core.jmx.camel.IBacklogTracerEventMessageMBean;
 
@@ -52,6 +53,7 @@ public class BacklogTracerEventMessage implements IBacklogTracerEventMessageMBea
 	 */
 	@Override
 	@XmlElement(name = "timestamp")
+	@XmlJavaTypeAdapter(DateAdapter.class)
 	public Date getTimestamp() {
 		return this.timestamp;
 	}

--- a/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/backlogtracermessage/DateAdapter.java
+++ b/jmx/plugins/org.fusesource.ide.jmx.commons/src/org/fusesource/ide/jmx/commons/backlogtracermessage/DateAdapter.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.jmx.commons.backlogtracermessage;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+/**
+ * @author Aurelien Pupier
+ *
+ */
+public class DateAdapter extends XmlAdapter<String, Date> {
+
+	protected static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+	private SimpleDateFormat dateFormat;
+
+	public DateAdapter() {
+		this.dateFormat = new SimpleDateFormat(DATE_FORMAT);
+	}
+
+	@Override
+	public Date unmarshal(String v) throws Exception {
+		return dateFormat.parse(v);
+	}
+
+	@Override
+	public String marshal(Date v) throws Exception {
+		return dateFormat.format(v);
+	}
+
+
+}

--- a/jmx/tests/org.fusesource.ide.jmx.commons.tests/src/test/java/org/fusesource/ide/jmx/commons/backlogtracermessage/BacklogTracerEventMessageParserTest.java
+++ b/jmx/tests/org.fusesource.ide.jmx.commons.tests/src/test/java/org/fusesource/ide/jmx/commons/backlogtracermessage/BacklogTracerEventMessageParserTest.java
@@ -10,7 +10,10 @@
  ******************************************************************************/
 package org.fusesource.ide.jmx.commons.backlogtracermessage;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import org.junit.Test;
 
@@ -19,14 +22,51 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class BacklogTracerEventMessageParserTest {
 
 	@Test
-	public void testGetBacklogTracerEventMessage() throws Exception {
-		InputStream stream = this.getClass().getResourceAsStream("backlogTracerEventMessage.xml");
-		String xmlDump = org.apache.commons.io.IOUtils.toString(stream);
+	public void testGetBacklogTracerEventMessage_messsageParsed() throws Exception {
+		String xmlDump = backlogTracerEventMessageDump();
 
 		BacklogTracerEventMessage backlogTracerEventMessage = new BacklogTracerEventMessageParser().getBacklogTracerEventMessage(xmlDump);
 
 		assertThat(backlogTracerEventMessage.getMessage()).isNotNull();
 	}
+
+	@Test
+	public void testGetBacklogTracerEventMessage_timestampParsed() throws Exception {
+		String xmlDump = backlogTracerEventMessageDump();
+
+		BacklogTracerEventMessage backlogTracerEventMessage = new BacklogTracerEventMessageParser().getBacklogTracerEventMessage(xmlDump);
+
+		final Date dateToCheck = new SimpleDateFormat(DateAdapter.DATE_FORMAT).parse("2016-04-01T17:09:44.635+0200");
+		assertThat(backlogTracerEventMessage.getTimestamp()).hasSameTimeAs(dateToCheck);
+	}
+
+	@Test
+	public void testGetBacklogTracerEventMessage_uidParsed() throws Exception {
+		String xmlDump = backlogTracerEventMessageDump();
+
+		BacklogTracerEventMessage backlogTracerEventMessage = new BacklogTracerEventMessageParser().getBacklogTracerEventMessage(xmlDump);
+
+		assertThat(backlogTracerEventMessage.getUid()).isEqualTo(5l);
+	}
+
+	@Test
+	public void testGetBacklogTracerEventMessage_exchangeIdParsed() throws Exception {
+		String xmlDump = backlogTracerEventMessageDump();
+
+		BacklogTracerEventMessage backlogTracerEventMessage = new BacklogTracerEventMessageParser().getBacklogTracerEventMessage(xmlDump);
+
+		assertThat(backlogTracerEventMessage.getExchangeId()).isEqualTo("ID-DESKTOP-9NT300B-61151-1459523299086-0-40");
+	}
+
+	/**
+	 * @return
+	 * @throws IOException
+	 */
+	private String backlogTracerEventMessageDump() throws IOException {
+		InputStream stream = this.getClass().getResourceAsStream("backlogTracerEventMessage.xml");
+		return org.apache.commons.io.IOUtils.toString(stream);
+	}
+
 
 	@Test
 	public void testGetBacklogTracerEventMessages() throws Exception {


### PR DESCRIPTION
The date format is hardcoded. It must corresponds to the hardcoded value in Camel core https://github.com/apache/camel/blob/camel-2.17.1/camel-core/src/main/java/org/apache/camel/api/management/mbean/BacklogTracerEventMessage.java#L28

What is the best to handle the correlation?