### PR TITLE
FUSETOOLS-1920 - Avoid NPE when there is no model linked to Editor

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/ImportCamelContextElementsCommand.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/commands/ImportCamelContextElementsCommand.java
@@ -112,10 +112,16 @@ public class ImportCamelContextElementsCommand extends RecordingCommand {
 		} catch (Exception ex) {
 			ex.printStackTrace();
 		} finally {
-			if (designEditor.getDiagramTypeProvider() != null) designEditor.getDiagramTypeProvider().resourceReloaded(diagram);
+			if (designEditor.getDiagramTypeProvider() != null){
+				designEditor.getDiagramTypeProvider().resourceReloaded(diagram);
+			}
 			designEditor.getParent().startDirtyListener();
-			designEditor.getModel().registerDOMListener();
-			if (context != null) context.ensureUniqueID(context);
+			if(designEditor.getModel() != null) {
+				designEditor.getModel().registerDOMListener();
+			}
+			if (context != null){
+				context.ensureUniqueID(context);
+			}
 		}
 	}
 	


### PR DESCRIPTION
I suppose that this use case might happen when there is an invalid xml
file.