### PR TITLE
FUSETOOLS-1970 - Ensure a build has been done before searching in Java

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/configurators/MavenTemplateConfigurator.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/configurators/MavenTemplateConfigurator.java
@@ -133,14 +133,12 @@ public class MavenTemplateConfigurator extends DefaultTemplateConfigurator {
 		    MavenPlugin.getMaven().writeModel(m2m, os);
 			IFile pomIFile2 = project.getProject().getFile("pom.xml");
 			if (pomIFile2 != null) {
-				pomIFile2.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
+				pomIFile2.refreshLocal(IResource.DEPTH_INFINITE, monitor);
 		    }
 			os.close();
 		} catch (Exception ex) {
 			ProjectTemplatesActivator.pluginLog().logError(ex);
 			return false;
-		} finally {
-			monitor.done();
 		}
 		return true;
 	}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
@@ -296,6 +297,11 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 	 * @return	the routebuilder class or null
 	 */
 	public static IFile findJavaDSLRouteBuilderClass(IProject project, IProgressMonitor monitor) {
+		try {
+			project.build(IncrementalProjectBuilder.INCREMENTAL_BUILD, monitor);
+		} catch (CoreException e) {
+			ProjectTemplatesActivator.pluginLog().logError(e);
+		}
 		try {
 			waitJob();
 		} catch (OperationCanceledException | InterruptedException e) {


### PR DESCRIPTION
classpath

- also wait for Refresh Build finished to avoid some "Resource out of
sync" even if no issue detected from that, except trace in log
- also provide the monitor and declare it as Done, the creator of the
monitor is reponsible for that.