### PR TITLE
FUSETOOLS-1953 - Better filtering to avoid logged exception and

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelFilesFinder.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelFilesFinder.java
@@ -69,6 +69,7 @@ public class CamelFilesFinder {
 	 */
 	public boolean isFuseCamelContentType(IFile ifile) throws CoreException {
 		return ifile != null
+				&& ifile.isSynchronized(IResource.DEPTH_ZERO)
 				&& ifile.getContentDescription() != null
 				&& ifile.getContentDescription()
 							.getContentType()

--- a/core/plugins/org.fusesource.ide.camel.validation/plugin.xml
+++ b/core/plugins/org.fusesource.ide.camel.validation/plugin.xml
@@ -12,9 +12,6 @@
             markerId="JBossFuseToolingValidationProblem">
          <include>
             <rules>
-               <fileext
-                     ext="xml">
-               </fileext>
                <contentType
                      exactMatch="false"
                      id="org.fusesource.ide.camel.editor.camelContentType">


### PR DESCRIPTION
initialization error

- avoid to trigger XML Camel Route validation on all xml files
- avoid to check for content types when file is out of sync