### PR TITLE
FUSETOOLS-1991 - Wait only 30 times for Job in case of

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
@@ -225,7 +225,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 						try {
 							if (!holder[0].exists()) {
 								try {
-									waitJob();
+									waitJob(20);
 								} catch (OperationCanceledException | InterruptedException e) {
 									ProjectTemplatesActivator.pluginLog().logError(e);
 									return;
@@ -285,7 +285,10 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 		}
 	}
 
-	private static void waitJob() throws OperationCanceledException, InterruptedException {
+	private static void waitJob(int decreasingCounter) throws InterruptedException {
+		if(decreasingCounter > 0){
+			return;
+		}
 		try {
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, new NullProgressMonitor());
 			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, new NullProgressMonitor());
@@ -294,7 +297,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 		} catch (InterruptedException e) {
 			// Workaround to bug
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=335251
-			waitJob();
+			waitJob(decreasingCounter--);
 		}
 	}
 	
@@ -312,7 +315,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 			ProjectTemplatesActivator.pluginLog().logError(e);
 		}
 		try {
-			waitJob();
+			waitJob(20);
 		} catch (OperationCanceledException | InterruptedException e) {
 			ProjectTemplatesActivator.pluginLog().logError(e);
 			return null;

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
@@ -225,7 +225,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 						try {
 							if (!holder[0].exists()) {
 								try {
-									waitJob(20);
+									waitJob(20, monitor);
 								} catch (OperationCanceledException | InterruptedException e) {
 									ProjectTemplatesActivator.pluginLog().logError(e);
 									return;
@@ -285,19 +285,19 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 		}
 	}
 
-	private static void waitJob(int decreasingCounter) throws InterruptedException {
+	private static void waitJob(int decreasingCounter, IProgressMonitor monitor) throws InterruptedException {
 		if(decreasingCounter > 0){
 			return;
 		}
 		try {
-			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, new NullProgressMonitor());
-			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, new NullProgressMonitor());
-			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, new NullProgressMonitor());
-			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, new NullProgressMonitor());
+			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_BUILD, monitor);
+			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_REFRESH, monitor);
+			Job.getJobManager().join(ResourcesPlugin.FAMILY_AUTO_REFRESH, monitor);
+			Job.getJobManager().join(ResourcesPlugin.FAMILY_MANUAL_BUILD, monitor);
 		} catch (InterruptedException e) {
 			// Workaround to bug
 			// https://bugs.eclipse.org/bugs/show_bug.cgi?id=335251
-			waitJob(decreasingCounter--);
+			waitJob(decreasingCounter--, monitor);
 		}
 	}
 	
@@ -315,7 +315,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 			ProjectTemplatesActivator.pluginLog().logError(e);
 		}
 		try {
-			waitJob(20);
+			waitJob(20, monitor);
 		} catch (OperationCanceledException | InterruptedException e) {
 			ProjectTemplatesActivator.pluginLog().logError(e);
 			return null;


### PR DESCRIPTION
InterruptedException

not a perfect solution, I can just hope that the Eclipse issue https://bugs.eclipse.org/bugs/show_bug.cgi?id=335251 won't be triggered too many triggered InteruptedException when importing a Camel project.
If it is the case, the user can still do alt+F5 after the import to workaround the issue.

previously, the camel facet were not imported something like 1 out 5 times on CI, so I will trigger the build 20 times to see if the workaround/fix is sustainable.