### PR TITLE
FUSETOOLS-1997 - Have deployment before build working

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/publish/jmx/KarafBundlesMBeanPublishBehaviour.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/publish/jmx/KarafBundlesMBeanPublishBehaviour.java
@@ -90,15 +90,13 @@ public class KarafBundlesMBeanPublishBehaviour extends
 		try {
 			this.objectName = new ObjectName(KARAF_BUNDLES_MBEAN);
 			
-			Set mbeans = mbsc.queryMBeans(this.objectName, null); 	    
+			Set<ObjectInstance> mbeans = mbsc.queryMBeans(this.objectName, null); 	    
 		    if (mbeans.size() == 1) {
 		    	// remember the mbean
 		    	Object oMbean = mbeans.iterator().next();
-		    	if (oMbean instanceof ObjectInstance) {
-		    		ObjectInstance oi = (ObjectInstance)oMbean;
-		    		this.objectName = oi.getObjectName();
-		    		return true;
-		    	}
+		    	ObjectInstance oi = (ObjectInstance)oMbean;
+		    	this.objectName = oi.getObjectName();
+		    	return true;
 		    }
 		} catch (Exception ex) {
 			Activator.getLogger().error(ex);

--- a/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/publish/jmx/MavenPublishController.java
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/src/org/fusesource/ide/server/karaf/core/publish/jmx/MavenPublishController.java
@@ -29,7 +29,7 @@ import org.jboss.ide.eclipse.as.wtp.core.server.behavior.IPublishControllerDeleg
 import org.jboss.ide.eclipse.as.wtp.core.server.behavior.util.PublishControllerUtil;
 
 public class MavenPublishController extends AbstractSubsystemController implements IPublishControllerDelegate {
-	public static final List<String> GOALS = Arrays.asList(new String[] {"clean", "package"});
+	public static final List<String> GOALS = Arrays.asList("clean", "package");
 
 	@Override
 	public int publishModule(int kind, int deltaKind, IModule[] module,


### PR DESCRIPTION
- call mvn package before each full publication of a Module.

the downside of this approach is that it takes more time to do a full publish BUT it forces to have an up-to-date version when we call "full publish" I think that it is what user wants

note: We don't have test with a Fuse Runtime Server, currently only QE does that