### PR TITLE
FUSETOOLS-2019 - Ensure Launch shortcuts available on source editor

### DIFF
--- a/editor/plugins/org.fusesource.ide.launcher.ui/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.launcher.ui/plugin.xml
@@ -275,7 +275,7 @@
            id="org.fusesource.ide.launcher.ui.localLaunchPropertyTester"
            namespace="org.fusesource.ide.launcher.ui"
            properties="isLocalLaunchAvailable"
-           type="org.eclipse.core.resources.IResource">
+           type="org.eclipse.core.runtime.IAdaptable">
      </propertyTester>
   </extension>  
    

--- a/editor/plugins/org.fusesource.ide.launcher.ui/src/org/fusesource/ide/launcher/ui/propertytester/CamelLocalLaunchPropertyTester.java
+++ b/editor/plugins/org.fusesource.ide.launcher.ui/src/org/fusesource/ide/launcher/ui/propertytester/CamelLocalLaunchPropertyTester.java
@@ -21,6 +21,7 @@ import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.m2e.core.MavenPlugin;
 import org.eclipse.m2e.core.project.IMavenProjectFacade;
@@ -38,11 +39,14 @@ public class CamelLocalLaunchPropertyTester extends PropertyTester {
 
 	@Override
 	public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
-		if(receiver instanceof IResource && IS_LOCAL_LAUNCH_AVAILABLE.equals(property)){
-			Model mavenModel = retrieveMavenModel((IResource) receiver);
-			if(mavenModel != null){
-				List<Plugin> plugins = retrievePlugins(mavenModel);
-				return containsCamelMavenPlugin(plugins);
+		if(receiver instanceof IAdaptable){
+			IResource resource = ((IAdaptable) receiver).getAdapter(IResource.class);
+			if(resource != null && IS_LOCAL_LAUNCH_AVAILABLE.equals(property)){
+				Model mavenModel = retrieveMavenModel(resource);
+				if(mavenModel != null){
+					List<Plugin> plugins = retrievePlugins(mavenModel);
+					return containsCamelMavenPlugin(plugins);
+				}
 			}
 		}
 		return false;

--- a/editor/tests/org.fusesource.ide.launcher.ui.tests/src/test/java/org/fusesource/ide/launcher/ui/propertytester/CamelLocalLaunchPropertyTesterTest.java
+++ b/editor/tests/org.fusesource.ide.launcher.ui.tests/src/test/java/org/fusesource/ide/launcher/ui/propertytester/CamelLocalLaunchPropertyTesterTest.java
@@ -17,14 +17,14 @@ import static org.mockito.Mockito.spy;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
-import org.assertj.core.api.Assertions;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.fusesource.ide.foundation.ui.io.CamelXMLEditorInput;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -51,6 +51,7 @@ public class CamelLocalLaunchPropertyTesterTest {
 		build.getPlugins().add(camelPlugin);
 		mavenModel.setBuild(build);
 		doReturn(mavenModel ).when(camelLocalLaunchPropertyTester).retrieveMavenModel(project);
+		doReturn(project).when(project).getAdapter(IResource.class);
 		
 		boolean res = camelLocalLaunchPropertyTester.test(project, CamelLocalLaunchPropertyTester.IS_LOCAL_LAUNCH_AVAILABLE, null, null);
 		
@@ -79,8 +80,27 @@ public class CamelLocalLaunchPropertyTesterTest {
 		build.getPlugins().add(camelPlugin);
 		mavenModel.setBuild(build);
 		doReturn(mavenModel).when(camelLocalLaunchPropertyTester).retrieveMavenModel(file);
+		doReturn(file).when(file).getAdapter(IResource.class);
 		
 		boolean res = camelLocalLaunchPropertyTester.test(file, CamelLocalLaunchPropertyTester.IS_LOCAL_LAUNCH_AVAILABLE, null, null);
+		
+		assertThat(res).isTrue();
+	}
+	
+	@Test
+	public void test_ReturnTrue_ForCamelXMLEditorInput() throws Exception {
+		CamelLocalLaunchPropertyTester camelLocalLaunchPropertyTester = spy(new CamelLocalLaunchPropertyTester());
+		Model mavenModel = new Model();
+		Build build = new Build();
+		Plugin camelPlugin = new Plugin();
+		camelPlugin.setGroupId("org.apache.camel");
+		camelPlugin.setArtifactId("camel-maven-plugin");
+		build.getPlugins().add(camelPlugin);
+		mavenModel.setBuild(build);
+		doReturn(mavenModel).when(camelLocalLaunchPropertyTester).retrieveMavenModel(file);
+		doReturn(file).when(file).getAdapter(IResource.class);
+		
+		boolean res = camelLocalLaunchPropertyTester.test(new CamelXMLEditorInput(file, null), CamelLocalLaunchPropertyTester.IS_LOCAL_LAUNCH_AVAILABLE, null, null);
 		
 		assertThat(res).isTrue();
 	}


### PR DESCRIPTION
- fix regression introduced by commit
687e901ddfbf85a37470ed1c55283279bf9dd630 which is hiding Launch
shortcuts for local camel context in case of missing camel-maven-plugin