### PR TITLE
FUSETOOLS-2071 - Set Fuse bom version when Target runtime selected

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/configurators/MavenTemplateConfigurator.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/configurators/MavenTemplateConfigurator.java
@@ -95,7 +95,7 @@ public class MavenTemplateConfigurator extends DefaultTemplateConfigurator {
 	}
 	
 	/**
-	 * changes all occurances of Camel version in the pom.xml file with the
+	 * changes all occurrences of Camel version in the pom.xml file with the
 	 * version defined in the wizard
 	 * 
 	 * @param project			the project
@@ -123,6 +123,10 @@ public class MavenTemplateConfigurator extends DefaultTemplateConfigurator {
 			subMonitor.worked(1);
 			
 			if(projectMetaData.getTargetRuntime() == null){
+				MavenUtils.alignFuseRuntimeVersion(m2m, camelVersion);
+			} else {
+				// we suppose that only one version of Fuse Runtime is possible for a Camel Version
+				//TODO: find a way to retrieve the Fuse Runtime BOM version from the Target Runtime
 				MavenUtils.alignFuseRuntimeVersion(m2m, camelVersion);
 			}
 			subMonitor.worked(1);

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/META-INF/MANIFEST.MF
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/META-INF/MANIFEST.MF
@@ -33,4 +33,5 @@ Require-Bundle: org.junit,
  org.fusesource.ide.projecttemplates;bundle-version="8.0.0",
  org.fusesource.ide.project;bundle-version="8.0.0",
  org.eclipse.jst.common.frameworks,
- org.eclipse.m2e.launching
+ org.eclipse.m2e.launching,
+ org.jboss.tools.locus.mockito;bundle-version="1.9.5"

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableCheckForBomVersionIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableCheckForBomVersionIT.java
@@ -1,0 +1,88 @@
+package org.fusesource.ide.projecttemplates.tests.integration.wizards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.management.MalformedObjectNameException;
+
+import org.apache.maven.project.MavenProject;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.debug.core.DebugException;
+import org.eclipse.m2e.core.MavenPlugin;
+import org.eclipse.m2e.core.project.IMavenProjectFacade;
+import org.eclipse.wst.server.core.IRuntime;
+import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
+import org.fusesource.ide.projecttemplates.adopters.util.CamelDSLType;
+import org.fusesource.ide.projecttemplates.util.NewProjectMetaData;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FuseIntegrationProjectCreatorRunnableCheckForBomVersionIT extends FuseIntegrationProjectCreatorRunnableIT {
+	
+	//TODO: runtime behavior will need to be updated in case we support direct retrieval of Fuse Runtime bom version from a Fuse Runtime server
+	@Mock
+	private IRuntime runtime;
+
+	@Test
+	public void testFuseBomAlignedToCamelVersionWhenNoTargetRuntimeSelected() throws Exception {
+		camelVersion = CamelModelFactory.getLatestCamelVersion();
+		
+		String projectNameSuffix = "-withoutRuntime-"+camelVersion;
+		final String projectName = getClass().getSimpleName() + projectNameSuffix;
+		
+		NewProjectMetaData metadata;
+		metadata = new NewProjectMetaData();
+		metadata.setProjectName(projectName);
+		metadata.setLocationPath(null);
+		metadata.setCamelVersion(camelVersion);
+		metadata.setTargetRuntime(null);
+		metadata.setDslType(CamelDSLType.SPRING);
+		metadata.setBlankProject(true);
+		metadata.setTemplate(null);
+		
+		testProjectCreation(projectNameSuffix, CamelDSLType.SPRING, "src/main/resources/META-INF/spring/camel-context.xml", metadata);
+		
+		checkBomVersion();
+	}
+	
+	@Test
+	public void testFuseBomAlignedToCamelVersionWhenTargetRuntimeSelected() throws Exception {
+		camelVersion = CamelModelFactory.getLatestCamelVersion();
+		
+		String projectNameSuffix = "-withRuntime-"+camelVersion;
+		final String projectName = getClass().getSimpleName() + projectNameSuffix;
+		
+		NewProjectMetaData metadata;
+		metadata = new NewProjectMetaData();
+		metadata.setProjectName(projectName);
+		metadata.setLocationPath(null);
+		metadata.setCamelVersion(camelVersion);
+		metadata.setTargetRuntime(runtime);
+		metadata.setDslType(CamelDSLType.SPRING);
+		metadata.setBlankProject(true);
+		metadata.setTemplate(null);
+		
+		testProjectCreation(projectNameSuffix, CamelDSLType.SPRING, "src/main/resources/META-INF/spring/camel-context.xml", metadata);
+		
+		checkBomVersion();
+	}
+	
+	private void checkBomVersion() throws CoreException {
+		IMavenProjectFacade mavenProjectFacade = MavenPlugin.getMavenProjectRegistry().getProject(project);
+		MavenProject mavenProject = mavenProjectFacade.getMavenProject(new NullProgressMonitor());
+		assertThat(mavenProject.getProperties().getProperty("jboss.fuse.bom.version")).isEqualTo(CamelModelFactory.getFuseVersionForCamelVersion(camelVersion));
+		
+	}
+
+	@Override
+	protected void launchDebug(IProject project) throws InterruptedException, IOException, MalformedObjectNameException, DebugException {
+		// not the purpose of this test
+	}
+	
+}


### PR DESCRIPTION
- currently rely on the fact the UI will have restrained the list of
possible choice and that we have a 1-1 mapping between fuse bom version
and camel version