### PR TITLE
FUSETOOLS-2018 - removing build path elements for Fuse 6.3 servers and

### DIFF
--- a/servers/plugins/org.fusesource.ide.server.karaf.core/plugin.xml
+++ b/servers/plugins/org.fusesource.ide.server.karaf.core/plugin.xml
@@ -376,11 +376,12 @@
    
    
   <!-- 		NEW_SERVER_ADAPTER add id for new runtime in the runtimeIds field below -->
-   <extension point="org.eclipse.jst.server.core.runtimeClasspathProviders">
+  <!--      THIS IS COMMENTED OUT FOR NOW TO AVOID AN ISSUE WITH DEPLOYMENT ON SY PROJECTS -->
+<!--   <extension point="org.eclipse.jst.server.core.runtimeClasspathProviders">
      <runtimeClasspathProvider
         id="org.fusesource.ide.server.karaf.core.runtime.classpath.runtimeTarget"
         runtimeTypeIds="org.fusesource.ide.karaf.runtime.22,org.fusesource.ide.karaf.runtime.23,org.fusesource.ide.karaf.runtime.24,org.fusesource.ide.karaf.runtime.30"
         class="org.fusesource.ide.server.karaf.core.runtime.classpath.KarafProjectRuntimeClasspathProvider"/>
-   </extension>
+   </extension> -->
    
 </plugin>


### PR DESCRIPTION
updating publishing to not do the maven build in the middle, while
adding the version to the deployed jar for more granularity