### PR TITLE
FUSETOOLS-2060 - Always return non-null value for iconName

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
@@ -1535,26 +1535,24 @@ public abstract class AbstractCamelModelElement {
 		if (isEndpointElement()) {
 			String u = (String) getParameter(URI_PARAMETER_KEY);
 			if (u != null && u.trim().length() > 0) {
-				String scheme = null;
 				if (u.startsWith("ref:")) {
 					// if its a ref we lookup what is the reference scheme
-					String refId = u.substring(u.indexOf(":") + 1);
+					String refId = u.substring(u.indexOf(':') + 1);
 					AbstractCamelModelElement endpointRef = getCamelContext().getEndpointDefinitions().get(refId);
 					if (endpointRef != null) {
 						String refUri = (String) endpointRef.getParameter(URI_PARAMETER_KEY);
 						if (refUri != null) {
-							scheme = refUri.substring(0, refUri.indexOf(":"));
+							return refUri.substring(0, refUri.indexOf(':'));
 						} else {
 							// seems we have a broken ref
 							return "endpoint";
 						}
 					}
 				} else {
-					if (u.indexOf(":") != -1) {
-						scheme = u.substring(0, u.indexOf(":"));
+					if (u.indexOf(':') != -1) {
+						return u.substring(0, u.indexOf(':'));
 					}
 				}
-				return scheme;
 			}
 			return "endpoint";
 		}

--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
@@ -1541,7 +1541,7 @@ public abstract class AbstractCamelModelElement {
 					AbstractCamelModelElement endpointRef = getCamelContext().getEndpointDefinitions().get(refId);
 					if (endpointRef != null) {
 						String refUri = (String) endpointRef.getParameter(URI_PARAMETER_KEY);
-						if (refUri != null) {
+						if (refUri != null && refUri.contains(":")) {
 							return refUri.substring(0, refUri.indexOf(':'));
 						} else {
 							// seems we have a broken ref

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests/src/test/java/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElementTest.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests/src/test/java/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElementTest.java
@@ -11,14 +11,17 @@
 package org.fusesource.ide.camel.model.service.core.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.*;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.w3c.dom.Node;
 
@@ -81,7 +84,32 @@ public class AbstractCamelModelElementTest {
 		doReturn("ref:unknow").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
 		
 		assertThat(cme.getIconName()).isEqualTo("endpoint");
+	}
+	
+	@Test
+	public void testgetIconNameReturnsReference() throws Exception {
+		doReturn("to").when(cme).getNodeTypeId();
+		doReturn("ref:aRef").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
+		AbstractCamelModelElement referencedEndpoint = Mockito.mock(AbstractCamelModelElement.class);
+		doReturn("bean:example").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
+		Map<String, AbstractCamelModelElement> map = new HashMap<>();
+		map.put("aRef", referencedEndpoint);
+		doReturn(map).when(context).getEndpointDefinitions();
 		
+		assertThat(cme.getIconName()).isEqualTo("bean");
+	}
+	
+	@Test
+	public void testgetIconNamehandleReferenceWithBadScheme() throws Exception {
+		doReturn("to").when(cme).getNodeTypeId();
+		doReturn("ref:aRef").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
+		AbstractCamelModelElement referencedEndpoint = Mockito.mock(AbstractCamelModelElement.class);
+		doReturn("bean").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
+		Map<String, AbstractCamelModelElement> map = new HashMap<>();
+		map.put("aRef", referencedEndpoint);
+		doReturn(map).when(context).getEndpointDefinitions();
+		
+		assertThat(cme.getIconName()).isEqualTo("endpoint");
 	}
 
 }

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests/src/test/java/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElementTest.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests/src/test/java/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElementTest.java
@@ -11,6 +11,7 @@
 package org.fusesource.ide.camel.model.service.core.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doReturn;
 
@@ -28,11 +29,16 @@ public class AbstractCamelModelElementTest {
 	private Node underlyingNode;
 	@Mock
 	private AbstractCamelModelElement cme;
+	@Mock
+	private CamelContextElement context;
 	
 	@Before
 	public void setup() {
 		doReturn("notEmptyUri").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
 		doCallRealMethod().when(cme).isEndpointElement();
+		doCallRealMethod().when(cme).getIconName();
+		doReturn(context).when(cme).getCamelContext();
+		
 	}
 
 	@Test
@@ -67,6 +73,15 @@ public class AbstractCamelModelElementTest {
 		assertThat((String)cme.getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY)).isNotEmpty();
 		
 		assertThat(cme.isEndpointElement()).isFalse();
+	}
+	
+	@Test
+	public void testgetIconNameReturnsDefaultValueForBadRef() throws Exception {
+		doReturn("to").when(cme).getNodeTypeId();
+		doReturn("ref:unknow").when(cme).getParameter(AbstractCamelModelElement.URI_PARAMETER_KEY);
+		
+		assertThat(cme.getIconName()).isEqualTo("endpoint");
+		
 	}
 
 }


### PR DESCRIPTION
there is another issue which is that the referenced endpoint is not resolved, but we will have the default icon instead of a NPE. Seems to be a first good step.