### PR TITLE
FUSETOOLS-2039 - Handle Export Package with Data Transformation

### DIFF
--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/l10n/Messages.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/l10n/Messages.java
@@ -270,6 +270,7 @@ public class Messages extends NLS {
 	public static String XMLPage_tooltipCombo;
 	public static String XMLPage_tooltipErrorOnlyOneElement;
 	public static String XMLPage_tooltipSelectFromList;
+	public static String UpdatingMANIFESTMF;
 
 	static {
 		// initialize resource bundle

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/l10n/messages.properties
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/l10n/messages.properties
@@ -247,4 +247,4 @@ XMLPage_tooltipBrowseXML=Browse to specify the XML file.
 XMLPage_tooltipCombo=This list will be populated as soon as an XML file is selected.
 XMLPage_tooltipErrorOnlyOneElement=Only one root element found.
 XMLPage_tooltipSelectFromList=Select from the available list of root elements.
-UpdatingMANIFESTMF="Updating MANIFEST.MF..."
+UpdatingMANIFESTMF=Updating MANIFEST.MF...

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/l10n/messages.properties
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/l10n/messages.properties
@@ -247,3 +247,4 @@ XMLPage_tooltipBrowseXML=Browse to specify the XML file.
 XMLPage_tooltipCombo=This list will be populated as soon as an XML file is selected.
 XMLPage_tooltipErrorOnlyOneElement=Only one root element found.
 XMLPage_tooltipSelectFromList=Select from the available list of root elements.
+UpdatingMANIFESTMF="Updating MANIFEST.MF..."

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/wizards/NewTransformationWizard.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/wizards/NewTransformationWizard.java
@@ -40,7 +40,6 @@ import org.eclipse.jface.operation.IRunnableWithProgress;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.Wizard;
-import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.eclipse.ui.IEditorDescriptor;
 import org.eclipse.ui.INewWizard;
 import org.eclipse.ui.IWorkbench;
@@ -61,8 +60,8 @@ import org.jboss.tools.fuse.transformation.core.model.json.JsonModelGenerator;
 import org.jboss.tools.fuse.transformation.core.model.xml.XmlModelGenerator;
 import org.jboss.tools.fuse.transformation.editor.Activator;
 import org.jboss.tools.fuse.transformation.editor.internal.l10n.Messages;
-import org.jboss.tools.fuse.transformation.editor.internal.util.JavaUtil;
 import org.jboss.tools.fuse.transformation.editor.internal.util.ImportExportPackageUpdater;
+import org.jboss.tools.fuse.transformation.editor.internal.util.JavaUtil;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util;
 import org.jboss.tools.fuse.transformation.editor.internal.wizards.JSONPage;
 import org.jboss.tools.fuse.transformation.editor.internal.wizards.JavaPage;
@@ -277,7 +276,7 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
 
                         // make sure we add our maven dependencies where needed
                         addCamelDozerDependency();
-                        new ImportExportPackageUpdater().updatePackageImports(project, sourceClassName, targetClassName, monitor);
+                        new ImportExportPackageUpdater(project, sourceClassName, targetClassName).updatePackageImports(monitor);
                         addDataFormatDefinitionDependency(sourceFormat);
                         addDataFormatDefinitionDependency(targetFormat);
 

--- a/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/wizards/NewTransformationWizard.java
+++ b/transformation/plugins/org.jboss.tools.fuse.transformation.editor/src/main/java/org/jboss/tools/fuse/transformation/editor/wizards/NewTransformationWizard.java
@@ -62,7 +62,7 @@ import org.jboss.tools.fuse.transformation.core.model.xml.XmlModelGenerator;
 import org.jboss.tools.fuse.transformation.editor.Activator;
 import org.jboss.tools.fuse.transformation.editor.internal.l10n.Messages;
 import org.jboss.tools.fuse.transformation.editor.internal.util.JavaUtil;
-import org.jboss.tools.fuse.transformation.editor.internal.util.ImportELPackageUpdater;
+import org.jboss.tools.fuse.transformation.editor.internal.util.ImportExportPackageUpdater;
 import org.jboss.tools.fuse.transformation.editor.internal.util.Util;
 import org.jboss.tools.fuse.transformation.editor.internal.wizards.JSONPage;
 import org.jboss.tools.fuse.transformation.editor.internal.wizards.JavaPage;
@@ -277,7 +277,7 @@ public class NewTransformationWizard extends Wizard implements INewWizard {
 
                         // make sure we add our maven dependencies where needed
                         addCamelDozerDependency();
-                        new ImportELPackageUpdater().updatePackageImports(project, monitor);
+                        new ImportExportPackageUpdater().updatePackageImports(project, sourceClassName, targetClassName, monitor);
                         addDataFormatDefinitionDependency(sourceFormat);
                         addDataFormatDefinitionDependency(targetFormat);
 

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/META-INF/MANIFEST.MF
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/META-INF/MANIFEST.MF
@@ -14,4 +14,6 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.fuse.transformation.editor;bundle-version="8.0.0",
  org.fusesource.ide.camel.model.service.core.tests.integration,
  org.eclipse.m2e.core,
- org.eclipse.pde.core;bundle-version="3.10.102"
+ org.eclipse.pde.core;bundle-version="3.10.102",
+ org.eclipse.jdt.core;bundle-version="3.11.2",
+ org.eclipse.jdt.launching;bundle-version="3.8.0"

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForManifestIT.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForManifestIT.java
@@ -30,7 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.osgi.framework.Constants;
 
-public class ImportELPackageUpdaterForManifestIT {
+public class ImportExportPackageUpdaterForManifestIT {
 	
 	private static final String POM_START = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
 			"<project xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd\"" +
@@ -52,7 +52,7 @@ public class ImportELPackageUpdaterForManifestIT {
 	
 
 	@Rule
-	public FuseProject fuseProject = new FuseProject(ImportELPackageUpdaterForManifestIT.class.getName());
+	public FuseProject fuseProject = new FuseProject(ImportExportPackageUpdaterForManifestIT.class.getName());
 	
 	private IProject project;
 	private IFile pomIFile;
@@ -70,12 +70,12 @@ public class ImportELPackageUpdaterForManifestIT {
 		pomIFile.create(new ByteArrayInputStream((POM_START + POM_END).getBytes(StandardCharsets.UTF_8)), true, new NullProgressMonitor());
 		manifestFile = project.getFile("src/main/resources/META-INF/MANIFEST.MF");
 		prepareFolder(project.getFolder("src/main/resources/META-INF/"));
-		manifestFile.create(ImportELPackageUpdaterForManifestIT.class.getResourceAsStream("/MANIFEST-Minimal.MF"), IResource.FORCE, new NullProgressMonitor());
+		manifestFile.create(ImportExportPackageUpdaterForManifestIT.class.getResourceAsStream("/MANIFEST-Minimal.MF"), IResource.FORCE, new NullProgressMonitor());
 	}
 	
 	@Test
 	public void testImportPackageAdded() {
-		new ImportELPackageUpdater().updatePackageImports(project, new NullProgressMonitor());
+		new ImportExportPackageUpdater().updatePackageImports(project, null, null, new NullProgressMonitor());
 		
 		WorkspaceBundleModel bundleModel = new WorkspaceBundleModel(manifestFile);
 		String importPackage = bundleModel.getBundle().getHeader(Constants.IMPORT_PACKAGE);
@@ -83,9 +83,37 @@ public class ImportELPackageUpdaterForManifestIT {
 	}
 	
 	@Test
+	public void testExportPackageAdded() {
+		new ImportExportPackageUpdater().updatePackageImports(project, "source.pack.MyClass", "target.pack.MyOtherClass", new NullProgressMonitor());
+		
+		WorkspaceBundleModel bundleModel = new WorkspaceBundleModel(manifestFile);
+		String exportPackage = bundleModel.getBundle().getHeader(Constants.EXPORT_PACKAGE);
+		assertThat(normalize(exportPackage)).isEqualTo(normalize("source.pack,target.pack"));
+	}
+	
+	@Test
+	public void testExportDefaultPackageAdded() {
+		new ImportExportPackageUpdater().updatePackageImports(project, "MyClass", "target.pack.MyOtherClass", new NullProgressMonitor());
+		
+		WorkspaceBundleModel bundleModel = new WorkspaceBundleModel(manifestFile);
+		String exportPackage = bundleModel.getBundle().getHeader(Constants.EXPORT_PACKAGE);
+		assertThat(normalize(exportPackage)).isEqualTo(normalize(".,target.pack"));
+	}
+	
+	@Test
+	public void testExportPackageNotAddedTwice() {
+		new ImportExportPackageUpdater().updatePackageImports(project, "source.pack.MyClass", "target.pack.MyOtherClass", new NullProgressMonitor());
+		new ImportExportPackageUpdater().updatePackageImports(project, "source.pack.MyClass", "target.pack.MyOtherClass", new NullProgressMonitor());
+		
+		WorkspaceBundleModel bundleModel = new WorkspaceBundleModel(manifestFile);
+		String exportPackage = bundleModel.getBundle().getHeader(Constants.EXPORT_PACKAGE);
+		assertThat(normalize(exportPackage)).isEqualTo(normalize("source.pack,target.pack"));
+	}
+	
+	@Test
 	public void testImportPackageNotAddedTwice() {
-		new ImportELPackageUpdater().updatePackageImports(project, new NullProgressMonitor());
-		new ImportELPackageUpdater().updatePackageImports(project, new NullProgressMonitor());
+		new ImportExportPackageUpdater().updatePackageImports(project, null, null, new NullProgressMonitor());
+		new ImportExportPackageUpdater().updatePackageImports(project, null, null, new NullProgressMonitor());
 		
 		WorkspaceBundleModel bundleModel = new WorkspaceBundleModel(manifestFile);
 		String importPackage = bundleModel.getBundle().getHeader(Constants.IMPORT_PACKAGE);

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForPomIT.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForPomIT.java
@@ -20,10 +20,8 @@ import java.text.StringCharacterIterator;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jface.util.SafeRunnable;
 import org.eclipse.m2e.core.internal.IMavenConstants;
 import org.fusesource.ide.camel.model.service.core.tests.integration.core.io.FuseProject;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -212,7 +210,7 @@ public class ImportExportPackageUpdaterForPomIT {
 	
 	private void updatePom(String pom, String expectedPom, String sourceClassName, String targetClassName) throws Exception {
 		pomIFile.create(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)), true, new NullProgressMonitor());
-		new ImportExportPackageUpdater().updatePackageImports(project, sourceClassName, targetClassName, new NullProgressMonitor());
+		new ImportExportPackageUpdater(project, sourceClassName, targetClassName).updatePackageImports(new NullProgressMonitor());
 		InputStream pomContentsToCheck = pomIFile.getContents();
 		char[] buf = new char[pomContentsToCheck.available()];
 		try (InputStreamReader reader = new InputStreamReader(pomContentsToCheck, StandardCharsets.UTF_8)) {

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForPomIT.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests.integration/src/main/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterForPomIT.java
@@ -28,7 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class ImportELPackageUpdaterForPomIT {
+public class ImportExportPackageUpdaterForPomIT {
 
 	private static final String VALID_INSTRUCTIONS =
 				"          <instructions>\n" +
@@ -53,7 +53,7 @@ public class ImportELPackageUpdaterForPomIT {
 			"  </build>\n" +
 			"</project>";
 
-	private static final String EXPECTED_POM = POM_START +
+	private static final String EXPECTED_POM_WITHOUT_EXPORT_PACKAGE = POM_START +
 			"      <plugin>\n" +
 			"		 <groupId>org.apache.felix</groupId>\n" +
 			"        <artifactId>maven-bundle-plugin</artifactId>\n" +
@@ -114,8 +114,37 @@ public class ImportELPackageUpdaterForPomIT {
 			"      </plugin>\n" +
 			POM_END;
 
+	private static final String EXPECTED_POM_WITH_EXPORT_PACKAGE = POM_START +
+			"      <plugin>\n" +
+			"		 <groupId>org.apache.felix</groupId>\n" +
+			"        <artifactId>maven-bundle-plugin</artifactId>\n" +
+			"        <version>3.2.0</version>\n" +
+			"		 <extensions>true</extensions>\n" +
+			"        <configuration>\n" +
+			"          <instructions>\n" +
+			"            <Export-Package>dummy.pack,source.pack,target.pack</Export-Package>\n" +
+			"		     <Import-Package>*,com.sun.el;version=\"[2,3)\"</Import-Package>\n" +
+			"		   </instructions>\n" +
+			"        </configuration>\n" +
+			"      </plugin>\n" +
+			POM_END;
+
+	private static final String POM_WITH_SOME_EXPORT_PACKAGE = POM_START +
+			"      <plugin>\n" +
+			"		 <groupId>org.apache.felix</groupId>\n" +
+			"        <artifactId>maven-bundle-plugin</artifactId>\n" +
+			"        <version>3.2.0</version>\n" +
+			"		 <extensions>true</extensions>\n" +
+			"        <configuration>\n" +
+			"          <instructions>\n" +
+			"            <Export-Package>dummy.pack</Export-Package>" +
+			"		   </instructions>\n" +
+			"        </configuration>\n" +
+			"      </plugin>\n" +
+			POM_END;
+
 	@Rule
-	public FuseProject fuseProject = new FuseProject(ImportELPackageUpdaterForPomIT.class.getName());
+	public FuseProject fuseProject = new FuseProject(ImportExportPackageUpdaterForPomIT.class.getName());
 
 	private IProject project;
 	private IFile pomIFile;
@@ -149,7 +178,7 @@ public class ImportELPackageUpdaterForPomIT {
 
 	@Test
 	public void shouldNotModifyExpectedPom() throws Exception {
-		updatePom(EXPECTED_POM);
+		updatePom(EXPECTED_POM_WITHOUT_EXPORT_PACKAGE);
 	}
 	
 	@Test
@@ -162,14 +191,28 @@ public class ImportELPackageUpdaterForPomIT {
 		String pom = POM_WITHOUT_PLUGIN.replace("bundle", "war");
 		updatePom(pom, pom);
 	}
+	
+	@Test
+	public void shouldNotAddExportedPackageIfNoExportPackageConfigured() throws Exception {
+		updatePom(EXPECTED_POM_WITHOUT_EXPORT_PACKAGE, EXPECTED_POM_WITHOUT_EXPORT_PACKAGE, "source.pack.MyClass", "target.pack.MyOtherClass");
+	}
+	
+	@Test
+	public void shouldAddExportedPackageIfExportPackageConfigured() throws Exception {
+		updatePom(POM_WITH_SOME_EXPORT_PACKAGE, EXPECTED_POM_WITH_EXPORT_PACKAGE, "source.pack.MyClass", "target.pack.MyOtherClass");
+	}
 
 	private void updatePom(String pom) throws Exception {
-		updatePom(pom, EXPECTED_POM);
+		updatePom(pom, EXPECTED_POM_WITHOUT_EXPORT_PACKAGE);
 	}
 
 	private void updatePom(String pom, String expectedPom) throws Exception {
+		updatePom(pom, expectedPom, null, null);
+	}
+	
+	private void updatePom(String pom, String expectedPom, String sourceClassName, String targetClassName) throws Exception {
 		pomIFile.create(new ByteArrayInputStream(pom.getBytes(StandardCharsets.UTF_8)), true, new NullProgressMonitor());
-		new ImportELPackageUpdater().updatePackageImports(project, new NullProgressMonitor());
+		new ImportExportPackageUpdater().updatePackageImports(project, sourceClassName, targetClassName, new NullProgressMonitor());
 		InputStream pomContentsToCheck = pomIFile.getContents();
 		char[] buf = new char[pomContentsToCheck.available()];
 		try (InputStreamReader reader = new InputStreamReader(pomContentsToCheck, StandardCharsets.UTF_8)) {

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/src/test/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterTest.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/src/test/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterTest.java
@@ -26,7 +26,7 @@ public class ImportExportPackageUpdaterTest {
 	public void testDependencyLowerTo217() throws Exception {
 		Model pomModel = createModelWithVersion("2.15.1");
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isFalse();
 	}
@@ -35,7 +35,7 @@ public class ImportExportPackageUpdaterTest {
 	public void testDependencyEqualTo217() throws Exception {
 		Model pomModel = createModelWithVersion("2.17.0");
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -44,7 +44,7 @@ public class ImportExportPackageUpdaterTest {
 	public void testDependencyHigherTo217() throws Exception {
 		Model pomModel = createModelWithVersion("2.18.0");
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -53,7 +53,7 @@ public class ImportExportPackageUpdaterTest {
 	public void testDependencyWithInvalidVersion_returnsTrueToEnsureAddingTheImportPackage() throws Exception {
 		Model pomModel = createModelWithVersion("Invalid");
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -64,7 +64,7 @@ public class ImportExportPackageUpdaterTest {
 		Build build = new Build();
 		pomModel.setBuild(build);
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -74,7 +74,7 @@ public class ImportExportPackageUpdaterTest {
 		Model pomModel = createModelWithVersion("2.17.0");
 		pomModel.setPackaging("war");
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isFalse();
 	}
@@ -87,7 +87,7 @@ public class ImportExportPackageUpdaterTest {
 		pomModel.setProperties(properties);
 		
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isFalse();
 	}
@@ -99,7 +99,7 @@ public class ImportExportPackageUpdaterTest {
 		properties.setProperty("camel.version", "2.17.0");
 		pomModel.setProperties(properties);
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -111,7 +111,7 @@ public class ImportExportPackageUpdaterTest {
 		properties.setProperty("camel.version", "Invalid");
 		pomModel.setProperties(properties);
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -120,7 +120,7 @@ public class ImportExportPackageUpdaterTest {
 	public void testDependencySpecifiedWithPropertyNotDefined() throws Exception {
 		Model pomModel = createModelWithVersion("${camel.version}");
 		
-		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater(null, null, null).shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}

--- a/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/src/test/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterTest.java
+++ b/transformation/tests/org.jboss.tools.fuse.transformation.editor.tests/src/test/java/org/jboss/tools/fuse/transformation/editor/internal/util/ImportExportPackageUpdaterTest.java
@@ -20,13 +20,13 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
 import org.junit.Test;
 
-public class ImportELPackageUpdaterTest {
+public class ImportExportPackageUpdaterTest {
 
 	@Test
 	public void testDependencyLowerTo217() throws Exception {
 		Model pomModel = createModelWithVersion("2.15.1");
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isFalse();
 	}
@@ -35,7 +35,7 @@ public class ImportELPackageUpdaterTest {
 	public void testDependencyEqualTo217() throws Exception {
 		Model pomModel = createModelWithVersion("2.17.0");
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -44,7 +44,7 @@ public class ImportELPackageUpdaterTest {
 	public void testDependencyHigherTo217() throws Exception {
 		Model pomModel = createModelWithVersion("2.18.0");
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -53,7 +53,7 @@ public class ImportELPackageUpdaterTest {
 	public void testDependencyWithInvalidVersion_returnsTrueToEnsureAddingTheImportPackage() throws Exception {
 		Model pomModel = createModelWithVersion("Invalid");
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -64,7 +64,7 @@ public class ImportELPackageUpdaterTest {
 		Build build = new Build();
 		pomModel.setBuild(build);
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -74,7 +74,7 @@ public class ImportELPackageUpdaterTest {
 		Model pomModel = createModelWithVersion("2.17.0");
 		pomModel.setPackaging("war");
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isFalse();
 	}
@@ -87,7 +87,7 @@ public class ImportELPackageUpdaterTest {
 		pomModel.setProperties(properties);
 		
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isFalse();
 	}
@@ -99,7 +99,7 @@ public class ImportELPackageUpdaterTest {
 		properties.setProperty("camel.version", "2.17.0");
 		pomModel.setProperties(properties);
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -111,7 +111,7 @@ public class ImportELPackageUpdaterTest {
 		properties.setProperty("camel.version", "Invalid");
 		pomModel.setProperties(properties);
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}
@@ -120,7 +120,7 @@ public class ImportELPackageUpdaterTest {
 	public void testDependencySpecifiedWithPropertyNotDefined() throws Exception {
 		Model pomModel = createModelWithVersion("${camel.version}");
 		
-		boolean shouldImport = new ImportELPackageUpdater().shouldAddImportPackage(pomModel);
+		boolean shouldImport = new ImportExportPackageUpdater().shouldAddImportExportPackage(pomModel);
 		
 		assertThat(shouldImport).isTrue();
 	}


### PR DESCRIPTION
- in case of using a commited MANIFEST.MF: complete the export-package
list in the Manifest.mf file
- in case of using maven-bundle-plugin:
-- if no export package configured at all: do nothing
-- if some export package configured: complete the export-package list
in the pom.xml for the maven-bundle-plugin