### PR TITLE
FUSETOOLS-2116 - projects using the same template shouldn't have same…

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
@@ -86,7 +86,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 
 	@Override
 	public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
-		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.FuseIntegrationProjectCreatorRunnable_CreatingTheProjectMonitorMessage, 8);
+		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.FuseIntegrationProjectCreatorRunnable_CreatingTheProjectMonitorMessage, 7);
 		// first create the project skeleton
 		BasicProjectCreator c = new BasicProjectCreator(metadata);
 		boolean ok = c.create(subMonitor.newChild(1));
@@ -122,7 +122,6 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 			prj.refreshLocal(IProject.DEPTH_INFINITE, subMonitor.newChild(1));
 			// update the manifest to reflect project name as Bundle-SymbolicName
 			updateBundleSymbolicName(prj, subMonitor.newChild(1));
-			prj.refreshLocal(IProject.DEPTH_INFINITE, subMonitor.newChild(1));
 		} catch (CoreException ex) {
 			ProjectTemplatesActivator.pluginLog().logError(ex);
 		}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/wizards/FuseIntegrationProjectCreatorRunnable.java
@@ -168,7 +168,7 @@ public final class FuseIntegrationProjectCreatorRunnable implements IRunnableWit
 				// lets also update the bundle name so Fuse Runtime shows a difference too
 				attributes.putValue("Bundle-Name", String.format("%s [%s]", attributes.getValue("Bundle-Name"), project.getName()));
 				mf.write(new FileOutputStream(f.getLocation().toFile()));
-				f.refreshLocal(0, monitor);
+				f.refreshLocal(IProject.DEPTH_ZERO, monitor);
 			} catch(IOException ioe) {
 				ProjectTemplatesActivator.pluginLog().logError(ioe);
 			}

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/BundleSymbolicNameCorrectionTest.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests/src/test/java/org/fusesource/ide/projecttemplates/BundleSymbolicNameCorrectionTest.java
@@ -1,0 +1,45 @@
+/******************************************************************************* 
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.projecttemplates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.fusesource.ide.projecttemplates.wizards.FuseIntegrationProjectCreatorRunnable;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author lhein
+ */
+public class BundleSymbolicNameCorrectionTest {
+	
+	private FuseIntegrationProjectCreatorRunnable runner;
+	
+	@Before
+	public void setup() {
+		runner = new FuseIntegrationProjectCreatorRunnable(null);
+	}
+	
+	@Test
+	public void testInvalidBundleSymbolicNameCorrection() throws Exception {
+		assertThat(runner.getBundleSymbolicNameForProjectName("Ä:strönge~P Oroject!;:~$! name_44")).isEqualToIgnoringCase("strngePOrojectname_44");
+	}
+	
+	@Test
+	public void testAlmostValidBundleSymbolicNameCorrection() throws Exception {
+		assertThat(runner.getBundleSymbolicNameForProjectName("My Test Project-33")).isEqualToIgnoringCase("MyTestProject-33");
+	}
+	
+	@Test
+	public void testValidBundleSymbolicNameCorrection() throws Exception {
+		assertThat(runner.getBundleSymbolicNameForProjectName("My_TestProject-33")).isEqualToIgnoringCase("My_TestProject-33");
+	}
+}


### PR DESCRIPTION
… bundle-symbolicname

This would cause confusion otherwise when someone creates 2 projects in
the workspace using the same template because the bundle-symbolicnames
would be identical and therefore overwrite each other if deployed to a
runtime. Bundle SymbolicName is now equal to the project name in eclipse
just replacing spaces with - chars.