### PR TITLE
FUSETOOLS-2061 - Respect Namespace for Global Definitions

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelFile.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/CamelFile.java
@@ -116,8 +116,8 @@ public class CamelFile extends AbstractCamelModelElement implements EventListene
 				if (child.getNodeType() != Node.ELEMENT_NODE) {
 					continue;
 				}
-            	String name = CamelUtils.getTranslatedNodeName(child);            	
-            	String id = child.getAttributes().getNamedItem("id") != null ? child.getAttributes().getNamedItem("id").getNodeValue() : CamelUtils.getTranslatedNodeName(child) + "-" + UUID.randomUUID().toString();
+            	String name = CamelUtils.getTranslatedNodeName(child);
+				String id = computeId(child);
             	if (name.equals(CAMEL_CONTEXT)) {
             		// found a camel context
             		CamelContextElement cce = new CamelContextElement(this, child);
@@ -133,6 +133,20 @@ public class CamelFile extends AbstractCamelModelElement implements EventListene
 					addGlobalDefinition(id, cme);
 				}
             }
+		}
+	}
+
+	private String computeId(Node child) {
+		Node idNode = child.getAttributes().getNamedItem("id");
+		if (idNode != null){
+			return idNode.getNodeValue();
+		} else if(child.getNamespaceURI() != null
+				&& !(child.getNamespaceURI().startsWith("http://camel.apache.org/schema/")
+						|| child.getNamespaceURI().startsWith("http://www.osgi.org/xmlns/blueprint/"/*v1.0.0*/)
+						|| child.getNamespaceURI().startsWith("http://www.springframework.org/schema/beans"))){
+			return null;
+		} else {
+			return CamelUtils.getTranslatedNodeName(child) + "-" + UUID.randomUUID().toString();
 		}
 	}
 

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/CamelIOHandlerIT.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/CamelIOHandlerIT.java
@@ -61,7 +61,8 @@ public class CamelIOHandlerIT {
 				"withGlobalDefinitionSample.xml",
 				"testWithCXFGlobalEndpoint.xml",
 				"emptyOtherwiseSample.xml",
-				"JMXBeanAnswer--camelContext--11--11.xml");
+				"JMXBeanAnswer--camelContext--11--11.xml",
+				"jaas-blueprint.xml");
 		//@formatter:on
 	}
 

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/jaas-blueprint.xml
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/jaas-blueprint.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	You under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:cm="http://aries.apache.org/blueprint/xmlns/blueprint-cm/v1.0.0"
+    xmlns:enc="http://karaf.apache.org/xmlns/jasypt/v1.0.0"
+    xmlns:jaas="http://karaf.apache.org/xmlns/jaas/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    <jaas:config name="karaf" rank="10">
+        <jaas:module
+            className="org.apache.karaf.jaas.modules.ldap.LDAPLoginModule" flags="required">
+
+			initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory
+			debug=true
+			connection.url=ldap://ldap-server.com:389
+			connection.username=uid=asdfasdf,dc=jboss,dc=com
+			connection.password=asdfasdfasdf
+			connection.protocol=
+			authentication=simple
+
+			role.base.dn=ou=users,ou=sth,dc=jboss,dc=com
+			user.filter=(uid=%u)
+			user.search.subtree=true
+
+			role.base.dn=ou=groups,ou=sth,dc=jboss,dc=com
+			role.name.attribute=cn
+			role.filter=(member=%fqdn)
+			role.search.subtree=true
+
+		</jaas:module>
+        <jaas:keystore keystorePassword="asdfasdf" name="truststore" path="classpath:some-truststore.ts"/>
+    </jaas:config>
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint" autoStartup="true" streamCache="false" id="context1"></camelContext>
+</blueprint>

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/globalconfiguration/CamelGlobalConfigEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/globalconfiguration/CamelGlobalConfigEditor.java
@@ -781,7 +781,7 @@ public class CamelGlobalConfigEditor extends EditorPart implements ICamelModelLi
 	}
 
 	private boolean supportsDelete(Object selObj) {
-		return selObj instanceof AbstractCamelModelElement || selObj instanceof Element;
+		return selObj instanceof AbstractCamelModelElement && ((AbstractCamelModelElement) selObj).getId() != null || selObj instanceof Element;
 	}
 
 	/**

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/globalconfiguration/GlobalConfigLabelProvider.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/globalconfiguration/GlobalConfigLabelProvider.java
@@ -34,7 +34,8 @@ class GlobalConfigLabelProvider implements IStyledLabelProvider {
 	private StyledString getStyledTextForCamelModelElement(AbstractCamelModelElement cme) {
 		StyledString text = new StyledString();
 		String type = getTypeFromExtensionPoint(cme);
-		text.append(cme.getId());
+		final String id = cme.getId();
+		text.append(id != null ? id : "<unknownId>");
 		if (!Strings.isEmpty(type)) {
 			text.append(" (" + type + ")", StyledString.COUNTER_STYLER);
 		}


### PR DESCRIPTION
- avoids to put ids for elements whcih don't support it
- avoids to show unsupported and unknown elements in Global
Configuration Editor that are part of other namespaces

Requires a validation from a Camel point of view:
- Am I missing some cases?
- Are we ok to hide elements in Configuration Editor that are not part of camel namespaces? (they can't be modified anyways)