### PR TITLE
FUSETOOLS-2117 - Improve compatibility with Spring IDE

### DIFF
--- a/editor/plugins/org.fusesource.ide.launcher.ui/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.launcher.ui/plugin.xml
@@ -246,17 +246,26 @@
                      <iterate>
                        <and>
                        <or>
-                         <adapt
-                               type="org.eclipse.core.resources.IFile">
-                            <test
-                                  property="org.eclipse.core.resources.contentTypeId"
-                                  value="org.fusesource.ide.camel.editor.camelContentType">
-                            </test>
-                         </adapt>
 						 <and>
 							<instanceof value="org.eclipse.core.resources.IProject" />
           					<test property="org.eclipse.core.resources.projectNature" value="org.fusesource.ide.project.RiderProjectNature" />
 						 </and>
+       <or>
+          <adapt
+                type="org.eclipse.core.resources.IFile">
+             <test
+                   property="org.eclipse.core.resources.contentTypeId"
+                   value="org.fusesource.ide.camel.editor.camelContentType">
+             </test>
+          </adapt>
+          <adapt
+                type="org.eclipse.core.resources.IFile">
+             <test
+                   property="org.eclipse.core.resources.contentTypeId"
+                   value="com.springsource.sts.config.ui.beanConfigFile">
+             </test>
+          </adapt>
+       </or>
                        </or>
                        <test
                              forcePluginActivation="true"


### PR DESCRIPTION
Allows to have Bean code completion in xml

- Fix creation of Spring Templates when Spring IDE is installed
- Fix "Launch as camel context" shortcut when Spring IDE is installed

Can't write tests with current state as we don't have Spring IDE in TP