### PR TITLE
FUSETOOLS-1899 - Avoid InterruptedException on project creation

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/model/AbstractCamelModelElement.java
@@ -974,13 +974,13 @@ public abstract class AbstractCamelModelElement {
 		String defaultValue = this.underlyingMetaModelObject != null
 				? this.underlyingMetaModelObject.getParameter(name).getDefaultValue() : null;
 		if (defaultValue != null && defaultValue.equals(getMappedValue(newValue))) {
-			// default value -> no need to explicitely set it -> delete
+			// default value -> no need to explicitly set it -> delete
 			// existing
 			e.removeAttribute(name);
 		} else {
 			// not the default value, so set it
 			e.setAttribute(name, getMappedValue(newValue));
-			if ("id".equals(name)) {
+			if ("id".equals(name) && oldValue != null && !oldValue.equals(newValue)) {
 				IEventBroker eventBroker = PlatformUI.getWorkbench().getService(IEventBroker.class);
 				Map<String, Object> eventMap = new HashMap<>();
 				eventMap.put(PROPERTY_KEY_OLD_ID, oldValue);

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableIT.java
@@ -273,6 +273,7 @@ public class FuseIntegrationProjectCreatorRunnableIT {
 		assertThat(editor).as("No editor has been opened.").isNotNull();
 		IEditorInput editorInput = editor.getEditorInput();
 		assertThat(editorInput.getAdapter(IFile.class)).isEqualTo(camelResource);
+		assertThat(editor.isDirty()).as("A newly created project should not have dirty editor.").isFalse();
 	}
 	
 	private void checkCorrectNatureEnabled(IProject project) throws CoreException {


### PR DESCRIPTION
- the InterruptedException was triggered by IEventBroker.send called
- at creation of a project, if all ids are set, this shoudln't be
called, I improved the condition
- I added in check in test to ensure that the editor is nto dirty (to be
sure that no id is generated/modified during project creation which can
cause the IEventBroker.send to be called