### PR TITLE
Fusetools 2152 use doc type to avoid warnings

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-blueprint/src/test/java/com/mycompany/camel/cxf/code/first/blueprint/incident/IncidentTest.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-blueprint/src/test/java/com/mycompany/camel/cxf/code/first/blueprint/incident/IncidentTest.java
@@ -52,9 +52,9 @@ public class IncidentTest {
          * ... and afterwards, we just read the SOAP response message that is sent back by the server.
          */
         InputStream is = connection.getInputStream();
-        System.out.println("the response is ====> ");
+        LOG.info("the response is ====> ");
         res = getStringFromInputStream(is);
-        System.out.println(res);
+        LOG.info(res);
         Assert.assertTrue(res.contains("30"));
     }
     

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-blueprint/src/test/resources/generated.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-blueprint/src/test/resources/generated.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE xml>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:inc="http://incident.blueprint.first.code.cxf.camel.mycompany.com/">
    <soapenv:Header/>
    <soapenv:Body>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java/src/test/java/com/mycompany/camel/cxf/code/first/java/incident/IncidentTest.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java/src/test/java/com/mycompany/camel/cxf/code/first/java/incident/IncidentTest.java
@@ -52,9 +52,9 @@ public class IncidentTest {
          * ... and afterwards, we just read the SOAP response message that is sent back by the server.
          */
         InputStream is = connection.getInputStream();
-        System.out.println("the response is ====> ");
+        LOG.info("the response is ====> ");
         res = getStringFromInputStream(is);
-        System.out.println(res);
+        LOG.info(res);
         Assert.assertTrue(res.contains("30"));
     }
     

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java/src/test/resources/generated.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-java/src/test/resources/generated.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE xml>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:inc="http://incident.java.first.code.cxf.camel.mycompany.com/">
    <soapenv:Header/>
    <soapenv:Body>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring/src/test/java/com/mycompany/camel/cxf/code/first/spring/incident/IncidentTest.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring/src/test/java/com/mycompany/camel/cxf/code/first/spring/incident/IncidentTest.java
@@ -52,9 +52,9 @@ public class IncidentTest {
          * ... and afterwards, we just read the SOAP response message that is sent back by the server.
          */
         InputStream is = connection.getInputStream();
-        System.out.println("the response is ====> ");
+        LOG.info("the response is ====> ");
         res = getStringFromInputStream(is);
-        System.out.println(res);
+        LOG.info(res);
         Assert.assertTrue(res.contains("30"));
     }
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring/src/test/resources/generated.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/medium/cxf-code-first/medium-fuse-cxf-code-first-spring/src/test/resources/generated.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE xml>
 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:inc="http://incident.spring.first.code.cxf.camel.mycompany.com/">
    <soapenv:Header/>
    <soapenv:Body>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="A0001">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="B0002">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="C0003">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="D0004">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-blueprint/src/main/resources/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="E0004">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/data/message1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/data/message1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <person user="james">
   <firstName>James</firstName>
   <lastName>Strachan</lastName>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/data/message2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/data/message2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <person user="hiram">
   <firstName>Hiram</firstName>
   <lastName>Chirino</lastName>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/data/message3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/data/message3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <person user="jon">
   <firstName>Jonathan</firstName>
   <lastName>Anstey</lastName>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="A0001">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="B0002">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="C0003">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="D0004">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-spring/src/main/resources/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <order xmlns="http://com.mycompany/examples/order">
 
     <customer id="E0004">

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order1.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order2.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order3.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order4.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order5.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0"?>
+<!DOCTYPE xml>
 <!--
     JBoss, Home of Professional Open Source
     Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual


### PR DESCRIPTION
now new project based on templates are created without warnings (and no errors of course) with exception:
- community version, due to the bom usage
- activemq dependency "duplicating" managed version

These 2 cases will need to be handled separately
