### PR TITLE
Clean code - use interface instead of Implementation

### DIFF
--- a/editor/plugins/org.fusesource.ide.launcher.ui/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.launcher.ui/META-INF/MANIFEST.MF
@@ -32,7 +32,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jface.text;bundle-version="3.9.0",
  org.fusesource.ide.launcher;bundle-version="9.1.0",
  org.fusesource.ide.foundation.core;bundle-version="9.1.0",
- org.fusesource.ide.foundation.ui;bundle-version="9.1.0"
+ org.fusesource.ide.foundation.ui;bundle-version="9.1.0",
+ org.fusesource.ide.camel.model.service.core
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.launcher.ui.Activator
 Bundle-ClassPath: .

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugTarget.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugTarget.java
@@ -45,6 +45,7 @@ import org.eclipse.debug.core.model.IProcess;
 import org.eclipse.debug.core.model.IThread;
 import org.fusesource.ide.camel.model.service.core.io.CamelIOHandler;
 import org.fusesource.ide.camel.model.service.core.jmx.camel.IBacklogTracerHeader;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.camel.model.service.core.model.CamelFile;
 import org.fusesource.ide.foundation.core.util.CamelUtils;
 import org.fusesource.ide.foundation.core.util.Strings;
@@ -105,7 +106,7 @@ public class CamelDebugTarget extends CamelDebugElement implements IDebugTarget 
 	/**
 	 * the debugger facade
 	 */
-	private CamelDebugFacade debugger;
+	private ICamelDebuggerMBeanFacade debugger;
 	
 	/**
 	 * Constructs a new debug target in the given launch for the 
@@ -531,7 +532,7 @@ public class CamelDebugTarget extends CamelDebugElement implements IDebugTarget 
 	 * 
 	 * @return
 	 */
-	public CamelDebugFacade getDebugger() {
+	public ICamelDebuggerMBeanFacade getDebugger() {
 		return this.debugger;
 	}
 	

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelStackFrame.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelStackFrame.java
@@ -19,6 +19,7 @@ import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.core.model.IThread;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.debug.core.model.IVariable;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.jmx.commons.backlogtracermessage.BacklogTracerEventMessage;
 import org.fusesource.ide.jmx.commons.backlogtracermessage.Message;
 import org.fusesource.ide.launcher.Activator;
@@ -303,7 +304,7 @@ public class CamelStackFrame extends CamelDebugElement implements IStackFrame, I
 		return contextFile != null ? contextFile.getName() : null;
 	}
 	
-	public CamelDebugFacade getDebugger() {
+	public ICamelDebuggerMBeanFacade getDebugger() {
 		return ((CamelDebugTarget)getDebugTarget()).getDebugger();
 	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelThread.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelThread.java
@@ -18,6 +18,7 @@ import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.core.model.IStackFrame;
 import org.eclipse.debug.core.model.IThread;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.jmx.commons.backlogtracermessage.BacklogTracerEventMessage;
 import org.fusesource.ide.launcher.Activator;
 import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
@@ -279,7 +280,7 @@ public class CamelThread extends CamelDebugElement implements IThread {
 	 * @see org.eclipse.debug.core.model.IStep#stepOver()
 	 */
 	public void stepOver() throws DebugException {
-		CamelDebugFacade debugger = ((CamelDebugTarget)getDebugTarget()).getDebugger();
+		ICamelDebuggerMBeanFacade debugger = ((CamelDebugTarget)getDebugTarget()).getDebugger();
 		String endpointId = ((CamelStackFrame)getTopStackFrame()).getEndpointId();
 		try {
 			// mark this thread as in stepping mode

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseCamelVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseCamelVariable.java
@@ -13,8 +13,8 @@ package org.fusesource.ide.launcher.debug.model.variables;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.debug.core.model.IVariable;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugElement;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 import org.fusesource.ide.launcher.debug.model.values.BaseCamelValue;
 
@@ -142,6 +142,6 @@ public class BaseCamelVariable extends CamelDebugElement implements IVariable {
 	/**
 	 * this method should be used to update the value in the runtime
 	 */
-	protected void updateValueOnRuntime(CamelDebugFacade debugger) throws DebugException {
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger) throws DebugException {
 	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseWritableCamelIntegerVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseWritableCamelIntegerVariable.java
@@ -11,7 +11,7 @@
 package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 
 /**
@@ -48,7 +48,7 @@ public class BaseWritableCamelIntegerVariable extends BaseWritableCamelVariable 
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseWritableCamelVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseWritableCamelVariable.java
@@ -12,7 +12,7 @@ package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 import org.fusesource.ide.launcher.debug.model.values.BaseCamelValue;
 
@@ -63,7 +63,7 @@ public class BaseWritableCamelVariable extends BaseCamelVariable {
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseWriteableCamelBooleanVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/BaseWriteableCamelBooleanVariable.java
@@ -11,7 +11,7 @@
 package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 
 /**
@@ -47,7 +47,7 @@ public class BaseWriteableCamelBooleanVariable extends BaseWritableCamelVariable
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 	}
 }

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyIncludeFilesVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyIncludeFilesVariable.java
@@ -11,7 +11,7 @@
 package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 
 /**
@@ -34,7 +34,7 @@ public class CamelBodyIncludeFilesVariable extends BaseWriteableCamelBooleanVari
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 		// change value
 		debugger.setBodyIncludeFiles(Boolean.parseBoolean(getValue().getValueString().trim()));

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyIncludeStreamsVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyIncludeStreamsVariable.java
@@ -11,7 +11,7 @@
 package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 
 /**
@@ -34,7 +34,7 @@ public class CamelBodyIncludeStreamsVariable extends BaseWriteableCamelBooleanVa
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 		// change value
 		debugger.setBodyIncludeStreams(Boolean.parseBoolean(getValue().getValueString().trim()));

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyMaxCharsVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyMaxCharsVariable.java
@@ -11,7 +11,7 @@
 package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 
 /**
@@ -34,7 +34,7 @@ public class CamelBodyMaxCharsVariable extends BaseWritableCamelIntegerVariable 
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 		// change value
 		debugger.setBodyMaxChars(Integer.parseInt(getValue().getValueString()));

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelBodyVariable.java
@@ -13,9 +13,9 @@ package org.fusesource.ide.launcher.debug.model.variables;
 import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.launcher.Activator;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 import org.fusesource.ide.launcher.debug.model.values.BaseCamelValue;
 
@@ -77,7 +77,7 @@ public class CamelBodyVariable extends BaseCamelVariable {
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 		if (Strings.isBlank(getValue().getValueString())) {
 			// remove value
@@ -93,7 +93,7 @@ public class CamelBodyVariable extends BaseCamelVariable {
 	 */
 	public void delete() {
 		try {
-			CamelDebugFacade debugger = ((CamelDebugTarget)getDebugTarget()).getDebugger();
+			ICamelDebuggerMBeanFacade debugger = ((CamelDebugTarget)getDebugTarget()).getDebugger();
 			debugger.removeMessageBodyOnBreakpoint(getCurrentEndpointNodeId());
 			if (Strings.isBlank(getValue().getValueString()) == false) {
 				super.setValue(new BaseCamelValue(fTarget, "[Body is null]", String.class));

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelHeaderVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelHeaderVariable.java
@@ -14,10 +14,10 @@ import org.eclipse.debug.core.DebugEvent;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
 import org.fusesource.ide.camel.model.service.core.jmx.camel.IBacklogTracerHeader;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.foundation.core.util.Strings;
 import org.fusesource.ide.jmx.commons.backlogtracermessage.Header;
 import org.fusesource.ide.launcher.Activator;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 import org.fusesource.ide.launcher.debug.model.values.CamelHeaderValue;
 
@@ -79,7 +79,7 @@ public class CamelHeaderVariable extends BaseCamelVariable {
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 		IBacklogTracerHeader h = ((CamelHeaderValue) getValue()).getHeader();
 		if (Strings.isBlank(h.getValue())) {

--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelLogLevelVariable.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/variables/CamelLogLevelVariable.java
@@ -11,7 +11,7 @@
 package org.fusesource.ide.launcher.debug.model.variables;
 
 import org.eclipse.debug.core.DebugException;
-import org.fusesource.ide.launcher.debug.model.CamelDebugFacade;
+import org.fusesource.ide.camel.model.service.core.jmx.camel.ICamelDebuggerMBeanFacade;
 import org.fusesource.ide.launcher.debug.model.CamelDebugTarget;
 
 /**
@@ -52,7 +52,7 @@ public class CamelLogLevelVariable extends BaseWritableCamelVariable {
 	 * @see org.fusesource.ide.launcher.debug.model.variables.BaseCamelVariable#updateValueOnRuntime(org.fusesource.ide.launcher.debug.model.CamelDebugFacade)
 	 */
 	@Override
-	protected void updateValueOnRuntime(CamelDebugFacade debugger)
+	protected void updateValueOnRuntime(ICamelDebuggerMBeanFacade debugger)
 			throws DebugException {
 		// change value
 		debugger.setLoggingLevel(getValue().getValueString().toUpperCase().trim());


### PR DESCRIPTION
this is cleaner to use the Interface and it will be required if we want to provide a Jolokia Implementation for debugging. this will allow to debug camel routes deployed on IoT devices using Eclipse Kura for instance
