### PR TITLE
FUSETOOLS-2170 - fixing missing dependency

### DIFF
--- a/core/plugins/org.fusesource.ide.maven/META-INF/MANIFEST.MF
+++ b/core/plugins/org.fusesource.ide.maven/META-INF/MANIFEST.MF
@@ -21,5 +21,6 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.refactoring,
  org.eclipse.m2e.scm,
  org.eclipse.m2e.maven.runtime;bundle-version="1.6.0",
- org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="1.6.0"
+ org.eclipse.m2e.maven.runtime.slf4j.simple;bundle-version="1.6.0",
+ org.sonatype.tycho.m2e;bundle-version="0.9.0";visibility:=reexport
 Export-Package: org.fusesource.ide.maven


### PR DESCRIPTION
I don't like this solution. I suspect the dependency isn't properly registered upstream from us somewhere, but this should take care of it at our level. 