### PR TITLE
JBTIS-982 - Add back sonatype m2e plugin

### DIFF
--- a/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.106.0",
  org.fusesource.ide.camel.model.service.core;bundle-version="9.0.0",
  org.fusesource.ide.camel.validation;bundle-version="9.0.0",
  org.fusesource.ide.camel.editor;bundle-version="9.0.0",
- org.eclipse.jst.server.core;bundle-version="1.2.400"
+ org.eclipse.jst.server.core;bundle-version="1.2.400",
+ org.sonatype.tycho.m2e;bundle-version="0.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.project.Activator
 Export-Package: org.fusesource.ide.project,


### PR DESCRIPTION
it is required to have maven-bundle-plugin working correctly and be able
to deploy immediately after creation of a project to a server