### PR TITLE
JBTIS-982 - Add back sonatype m2e plugin

### DIFF
--- a/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
+++ b/editor/plugins/org.fusesource.ide.project/META-INF/MANIFEST.MF
@@ -37,7 +37,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.106.0",
  org.fusesource.ide.camel.model.service.core;bundle-version="9.1.0",
  org.fusesource.ide.camel.validation;bundle-version="9.1.0",
  org.fusesource.ide.camel.editor;bundle-version="9.1.0",
- org.eclipse.jst.server.core;bundle-version="1.2.400"
+ org.eclipse.jst.server.core;bundle-version="1.2.400",
+ org.sonatype.tycho.m2e;bundle-version="0.9.0"
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.fusesource.ide.project.Activator
 Export-Package: org.fusesource.ide.project,

--- a/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/DependencyCheckIT.java
+++ b/editor/tests/org.fusesource.ide.project.tests.integration/src/main/java/org/fusesource/ide/project/DependencyCheckIT.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.fusesource.ide.project;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.InputStream;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+
+import org.junit.Test;
+import org.osgi.framework.Constants;
+
+public class DependencyCheckIT {
+	
+	@Test
+	public void testSonatypeDependencyAvailable() throws Exception {
+		InputStream manifestStream = Activator.class.getResourceAsStream("/META-INF/MANIFEST.MF");
+		Manifest manifest = new Manifest(manifestStream);
+		Attributes mainAttributes = manifest.getMainAttributes();
+		String requireBundles = mainAttributes.getValue(Constants.REQUIRE_BUNDLE);
+		assertThat(requireBundles).contains("org.sonatype.tycho.m2e");
+	}
+
+}


### PR DESCRIPTION
it is required to have maven-bundle-plugin working correctly and be able
to deploy immediately after creation of a project to a server