### PR TITLE
FUSETOOLS-2023 - Remove namespace example in When xpath expressions

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="A0001">
 		<name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="B0002">
 		<name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="C0003">
 		<name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="D0004">
 		<name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/amq/simple-fuse-activemq-java/src/test/resources/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="A0001">
         <name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="B0002">
         <name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="C0003">
         <name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="D0004">
         <name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -25,14 +25,13 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="              http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd              http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
     <!--
-      The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'. Additionally,
-      we can also define namespace prefixes we want to use them in the XPath expressions in our CBR.
+      The namespace for the camelContext element in Blueprint is 'https://camel.apache.org/schema/blueprint'.
 
       While it is not required to assign id's to the <camelContext/> and <route/> elements, it is a good idea
       to set those for runtime management purposes (logging, JMX MBeans, ...)
     -->
     <camelContext id="cbr-example-context"
-        xmlns="http://camel.apache.org/schema/blueprint" xmlns:order="http://fabric8.com/examples/order/v7">
+        xmlns="http://camel.apache.org/schema/blueprint">
         <!--
           When this route is started, it will automatically create the work/cbr/input directory where you can drop the
           file that need to be processed.
@@ -50,12 +49,12 @@
             <log id="_log1" message="Receiving order ${file:name}"/>
             <choice id="_choice1">
                 <when id="_when1">
-                    <xpath id="_xpath1">/order:order/order:customer/order:country = 'UK'</xpath>
+                    <xpath id="_xpath1">/order/customer/country = 'UK'</xpath>
                     <log id="_log2" message="Sending order ${file:name} to the UK"/>
                     <to id="_to1" uri="file:work/cbr/output/uk"/>
                 </when>
                 <when id="_when2">
-                    <xpath id="_xpath2">/order:order/order:customer/order:country = 'US'</xpath>
+                    <xpath id="_xpath2">/order/customer/country = 'US'</xpath>
                     <log id="_log3" message="Sending order ${file:name} to the US"/>
                     <to id="_to2" uri="file:work/cbr/output/us"/>
                 </when>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="A0001">
         <name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="B0002">
         <name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="C0003">
         <name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="D0004">
         <name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-blueprint/src/test/resources/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="A0001">
         <name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="B0002">
         <name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="C0003">
         <name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="D0004">
         <name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/java/com/mycompany/camel/CamelRoute.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/main/java/com/mycompany/camel/CamelRoute.java
@@ -1,7 +1,6 @@
 package com.mycompany.camel;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.builder.xml.Namespaces;
 
 public class CamelRoute extends RouteBuilder {
 
@@ -20,15 +19,14 @@ public class CamelRoute extends RouteBuilder {
         either of the <when/> elements will be moved to the work/cbr/output/others directory.
         
 		 */
-		Namespaces ns = new Namespaces("c", "http://fabric8.com/examples/order/v7");
 
 		from("file:work/cbr/input")
 			.log("Receiving order ${file:name}")
 			.choice()
-				.when(ns.xpath("//c:order/c:customer/c:country[text() = 'UK']"))
+				.when().xpath("//order/customer/country[text() = 'UK']")
 					.log("Sending order ${file:name} to the UK")
 					.to("file:work/cbr/output/uk")
-				.when(ns.xpath("//c:order/c:customer/c:country[text() = 'US']"))
+				.when().xpath("//order/customer/country[text() = 'US']")
 					.log("Sending order ${file:name} to the US")
 					.to("file:work/cbr/output/us")
 				.otherwise()

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="A0001">
 		<name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="B0002">
 		<name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="C0003">
 		<name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
 	<customer id="D0004">
 		<name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-java/src/test/resources/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="A0001">
         <name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="B0002">
         <name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="C0003">
         <name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="D0004">
         <name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/resources/META-INF/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/main/resources/META-INF/spring/camel-context.xml
@@ -18,7 +18,7 @@
 <!-- Configures the Camel Context-->
 <beans xmlns="http://www.springframework.org/schema/beans"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="        http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd        http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
-    <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/spring" xmlns:order="http://fabric8.com/examples/order/v7">
+    <camelContext id="cbr-example-context" xmlns="http://camel.apache.org/schema/spring">
         <!--
           When this route is started, it will automatically create the work/cbr/input directory where you can drop the
           file that need to be processed.
@@ -36,12 +36,12 @@
             <log id="_log1" message="Receiving order ${file:name}"/>
             <choice id="_choice1">
                 <when id="_when1">
-                    <xpath id="_xpath1">/order:order/order:customer/order:country = 'UK'</xpath>
+                    <xpath id="_xpath1">/order/customer/country = 'UK'</xpath>
                     <log id="_log2" message="Sending order ${file:name} to the UK"/>
                     <to id="_to1" uri="file:work/cbr/output/uk"/>
                 </when>
                 <when id="_when2">
-                    <xpath id="_xpath2">/order:order/order:customer/order:country = 'US'</xpath>
+                    <xpath id="_xpath2">/order/customer/country = 'US'</xpath>
                     <log id="_log3" message="Sending order ${file:name} to the US"/>
                     <to id="_to2" uri="file:work/cbr/output/us"/>
                 </when>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order1.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order1.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="A0001">
         <name>Antwerp Zoo</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order2.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order2.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="B0002">
         <name>Bristol Zoo Gardens</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order3.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order3.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="C0003">
         <name>Columbus Zoo and Aquarium</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order4.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order4.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="D0004">
         <name>Dartmoor Zoological Park</name>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order5.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/cbr/simple-fuse-cbr-spring/src/test/resources/data/order5.xml
@@ -16,7 +16,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<order xmlns="http://fabric8.com/examples/order/v7">
+<order>
 
     <customer id="E0004">
         <name>Erie Zoo</name>


### PR DESCRIPTION
due to Camel bug https://issues.apache.org/jira/browse/CAMEL-10509

avoid usage of namespace in When XPath to avoid users to hit the Camel
bug when using a provided template