### PR TITLE
Clean code - use xml Doctype declaration when no xsd/dtd available

### DIFF
--- a/editor/plugins/org.fusesource.ide.project/lifecycle-mapping-metadata.xml
+++ b/editor/plugins/org.fusesource.ide.project/lifecycle-mapping-metadata.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <lifecycleMappingMetadata>
 
 	<pluginExecutions>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/lifecycle-mapping-metadata.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/lifecycle-mapping-metadata.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <lifecycleMappingMetadata>
 
 	<pluginExecutions>


### PR DESCRIPTION
it avoids to have warnings in Eclipse