### PR TITLE
FUSETOOLS-2213 - Upgrade Target Platform to 4.4.1.CR1

### DIFF
--- a/jmx/tests/org.fusesource.ide.jmx.commons.tests/META-INF/MANIFEST.MF
+++ b/jmx/tests/org.fusesource.ide.jmx.commons.tests/META-INF/MANIFEST.MF
@@ -7,5 +7,5 @@ Fragment-Host: org.fusesource.ide.jmx.commons;bundle-version="9.1.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Require-Bundle: org.junit;bundle-version="4.11.0",
  org.assertj.core;bundle-version="2.1.0",
- org.apache.commons.io;bundle-version="2.4.0",
+ org.apache.commons.io;bundle-version="2.2.0",
  org.jboss.tools.locus.mockito

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- JBoss Tools Integration Stack version -->
-    <jbtis.version>4.4.0.Final</jbtis.version>
+    <jbtis.version>4.4.1.CR1</jbtis.version>
     <jbtis.classifier>base</jbtis.classifier> <!-- base-ea -->
     
     <!-- Tycho versions -->


### PR DESCRIPTION
- upgrade TP
- also downgrade commons.io dependency to 2.2 as 2.4 as been removed