### PR TITLE
FUSETOOLS-2216 - Basic support of list of elements for an eip not at

### DIFF
--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/CamelIOHandlerIT.java
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/java/org/fusesource/ide/camel/model/service/core/tests/integration/core/io/CamelIOHandlerIT.java
@@ -65,7 +65,8 @@ public class CamelIOHandlerIT {
 				"jaas-blueprint.xml",
 				"withQuestionMark.xml",
 				"globalElementsSample.xml",
-				"routes.xml");
+				"routes.xml",
+				"withMarshalCsvHeaders.xml");
 		//@formatter:on
 	}
 

--- a/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/withMarshalCsvHeaders.xml
+++ b/core/tests/org.fusesource.ide.camel.model.service.core.tests.integration/src/main/resources/withMarshalCsvHeaders.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.osgi.org/xmlns/blueprint/v1.0.0 https://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd                            http://camel.apache.org/schema/blueprint http://camel.apache.org/schema/blueprint/camel-blueprint.xsd">
+    <camelContext id="_context1" xmlns="http://camel.apache.org/schema/blueprint">
+        <route id="extract-route">
+                     <from id="cron" uri="{{extract.schedule}}"/>
+            <transacted id="_transacted" ref="PROPAGATION_REQUIRED"/>
+            <log id="log_start" message="Firing db call"/>
+            <to id="to_select" uri="sql:classpath:cx_extract_combined.sql"/>
+            <to id="to_update" uri="sql:{{sql.cx.update}}"/>
+            <marshal id="marshal">
+                <csv delimiter="|">
+                    <header>person_id</header>
+                    <header>first_name</header>
+                    <header>last_name</header>
+                    <header>email_address</header>
+                    <header>collar_number</header>
+                    <header>user_id</header>
+                    <header>ex_employee</header>
+                    <header>post_rank</header>
+                    <header>job_title</header>
+                </csv>
+            </marshal>
+            <to id="to_local_file" uri="{{local.generated.file.path}}?fileName=cx_export.csv.${date:now:yyyy-MM-dd-HHmmss}&amp;tempPrefix=."/>
+              </route>
+    </camelContext>
+</blueprint>

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/FusePropertySection.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/FusePropertySection.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.eclipse.core.databinding.DataBindingContext;
 import org.eclipse.core.databinding.observable.map.IObservableMap;
@@ -79,7 +80,7 @@ public abstract class FusePropertySection extends AbstractPropertySection {
 	protected FormToolkit toolkit;
 	protected Form form;
 	protected CTabFolder tabFolder;
-	protected List<CTabItem> tabs = new ArrayList<CTabItem>();
+	protected List<CTabItem> tabs = new ArrayList<>();
 	protected AbstractCamelModelElement selectedEP;
 	protected AbstractCamelModelElement lastSelectedEP;
 	protected DataBindingContext dbc;
@@ -681,6 +682,23 @@ public abstract class FusePropertySection extends AbstractPropertySection {
 			txtField.setLayoutData(createPropertyFieldLayoutData());
 			c = txtField;
 
+			// grand Children inside a list of nodes
+		} else if(camelModelElement != null && camelModelElement.getParameter(p.getName()) instanceof List){
+			//TODO: use something better than a text for a list of elements as we have the obvious limitation of not supporting the ","
+			List<String> initialValue = (List<String>)camelModelElement.getParameter(p.getName());
+			String delimiter = ",";
+			String collect = initialValue.stream().collect(Collectors.joining(delimiter));
+			Text txtField = getWidgetFactory().createText(parent, collect, SWT.SINGLE | SWT.LEFT);
+			txtField.addModifyListener(new ModifyListener() {
+				@Override
+				public void modifyText(ModifyEvent e) {
+					Text txt = (Text) e.getSource();
+					camelModelElement.setParameter(p.getName(), Arrays.asList(txt.getText().split(delimiter)));
+				}
+			});
+			txtField.setLayoutData(createPropertyFieldLayoutData());
+			c = txtField;
+			
 			// OTHER
 		} else {
 			String initialValue = null;


### PR DESCRIPTION
first level

- current limitation is that elements can not contains a "," character
(still better than corrupting the data everytime before)
- in eips provided, no use case detected in which a "," can be used.
- UIs is providing a simple text comma separated