### PR TITLE
FUSETOOLS-2151 - Provide basic OSE SpringBoot template

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/OSGI-INF/l10n/bundle.properties
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/OSGI-INF/l10n/bundle.properties
@@ -35,3 +35,5 @@ template.medium.cxf.code.first.name = CXF code first
 template.medium.cxf.code.first.description = This template provides a sample Camel route definition which is started by a CXF Webservice call.
 extension-point.name = projectTemplates
 integration.preferences.project.templates=Staging Repositories
+template.simple.osespringboot.xml.name=SpringBoot on OpenShift
+template.simple.osespringboot.xml.description=This example demonstrates how to configure Camel routes in Spring Boot via a Spring XML configuration file.

--- a/editor/plugins/org.fusesource.ide.projecttemplates/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/plugin.xml
@@ -133,6 +133,15 @@
           name="%template.medium.eapspring.name"
           weight="0">
     </projectTemplate>
+    <projectTemplate
+          category="fuse.projecttemplates.ose"
+          class="org.fusesource.ide.projecttemplates.impl.simple.OSESpringBootXMLTemplate"
+          description="%template.simple.osespringboot.xml.description"
+          id="org.fusesource.ide.projecttemplates.oseSpringBoot"
+          keywords="ose openshift springboot"
+          name="%template.simple.osespringboot.xml.name"
+          weight="50">
+    </projectTemplate>
  </extension>
  
  <!-- Maven configurator  -->

--- a/editor/plugins/org.fusesource.ide.projecttemplates/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/pom.xml
@@ -225,6 +225,24 @@
               				</fileset>
             			</configuration>
           			</execution>
+          			
+          			<!-- SIMPLE-OSE-SPRINGBOOT TEMPLATE -->
+          			<execution>
+            			<id>create-template-simple-ose-springboot</id>
+            			<goals>
+              				<goal>copy</goal>
+            			</goals>
+            			<phase>generate-resources</phase>
+            			<configuration>
+              				<fileset>
+                				<directory>template-sources/simple/ose/simple-ose-log-springboot</directory>
+                				<includes>
+                  					<include>**</include>
+                				</includes>
+                				<outputDirectory>templates/template-simple-ose-log-springboot.zip</outputDirectory>
+              				</fileset>
+            			</configuration>
+          			</execution>
 				</executions>
       		</plugin>
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/OSESpringBootXMLTemplate.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/impl/simple/OSESpringBootXMLTemplate.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.projecttemplates.impl.simple;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.ZipInputStream;
+
+import org.fusesource.ide.projecttemplates.adopters.AbstractProjectTemplate;
+import org.fusesource.ide.projecttemplates.adopters.configurators.MavenTemplateConfigurator;
+import org.fusesource.ide.projecttemplates.adopters.configurators.TemplateConfiguratorSupport;
+import org.fusesource.ide.projecttemplates.adopters.creators.TemplateCreatorSupport;
+import org.fusesource.ide.projecttemplates.adopters.creators.UnzipStreamCreator;
+import org.fusesource.ide.projecttemplates.adopters.util.CamelDSLType;
+import org.fusesource.ide.projecttemplates.internal.ProjectTemplatesActivator;
+import org.fusesource.ide.projecttemplates.util.NewProjectMetaData;
+
+public class OSESpringBootXMLTemplate extends AbstractProjectTemplate {
+	
+	@Override
+	public boolean supportsDSL(CamelDSLType type) {
+		return type == CamelDSLType.SPRING;
+	}
+	
+	@Override
+	public TemplateConfiguratorSupport getConfigurator() {
+		return new MavenTemplateConfigurator();
+	}
+
+	@Override
+	public TemplateCreatorSupport getCreator(NewProjectMetaData projectMetaData) {
+		return new OSEUnzipTemplateCreator();
+	}
+	
+	/**
+	 * creator class for the CBR simple template 
+	 */
+	private class OSEUnzipTemplateCreator extends UnzipStreamCreator {
+
+		private static final String TEMPLATE_FOLDER = "templates/";
+		private static final String TEMPLATE_SPRING = "template-simple-ose-log-springboot.zip";
+		
+		@Override
+		public InputStream getTemplateStream(NewProjectMetaData metadata) throws IOException {
+			String bundleEntry = null;
+			CamelDSLType dslType = metadata.getDslType();
+			if (dslType == CamelDSLType.SPRING) {
+				bundleEntry = String.format("%s%s", TEMPLATE_FOLDER, TEMPLATE_SPRING);
+			}
+			URL archiveUrl = ProjectTemplatesActivator.getBundleContext().getBundle().getEntry(bundleEntry);
+			if (archiveUrl != null) {
+				InputStream is = null;
+				try {
+					is = archiveUrl.openStream();
+					return new ZipInputStream(is, StandardCharsets.UTF_8);
+				} catch (IOException ex) {
+					ProjectTemplatesActivator.pluginLog().logError(ex);
+				}			
+			}
+			return null;
+		}
+	}
+
+}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/maven/CamelProjectConfigurator.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/maven/CamelProjectConfigurator.java
@@ -10,11 +10,16 @@
  ******************************************************************************/
 package org.fusesource.ide.projecttemplates.maven;
 
+import java.io.BufferedOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
@@ -50,6 +55,7 @@ import org.fusesource.ide.projecttemplates.internal.ProjectTemplatesActivator;
 import org.fusesource.ide.projecttemplates.util.camel.CamelFacetDataModelProvider;
 import org.fusesource.ide.projecttemplates.util.camel.CamelFacetVersionChangeDelegate;
 import org.fusesource.ide.projecttemplates.util.camel.ICamelFacetDataModelProperties;
+import org.fusesource.ide.projecttemplates.util.maven.MavenUtils;
 
 public class CamelProjectConfigurator extends AbstractProjectConfigurator {
 
@@ -108,6 +114,15 @@ public class CamelProjectConfigurator extends AbstractProjectConfigurator {
 			// handle linked resources for WAR deployments
 			if (isWARProject(request.getProject(), monitor)) {
 				configureWARStructureMapping(request.getProject(), monitor);
+			}
+			
+			Model mavenModel = request.getMavenProject().getModel();
+			if(MavenUtils.manageStagingRepositories(mavenModel)){
+				try (OutputStream os = new BufferedOutputStream(new FileOutputStream(request.getMavenProject().getFile()))){
+					MavenPlugin.getMaven().writeModel(mavenModel, os);
+				} catch (IOException e) {
+					ProjectTemplatesActivator.pluginLog().logError(e);
+				}
 			}
 		}
 	}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/preferences/initializer/StagingRepositoriesPreferenceInitializer.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/preferences/initializer/StagingRepositoriesPreferenceInitializer.java
@@ -23,7 +23,7 @@ public class StagingRepositoriesPreferenceInitializer extends AbstractPreference
 	
 	private static final String PRODUCT_STAGING_REPO_URI = "fuse-internal"+ 
 			StagingRepositoriesConstants.NAME_URL_SEPARATOR+
-			"http://download.eng.brq.redhat.com/brewroot/repos/jb-fuse-6.2-build/latest/maven";
+			"http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-common-build/latest/maven/";
 	private static final String THIRD_PARTY_STAGING_REPO_URI = "redhat-ea"+
 			StagingRepositoriesConstants.NAME_URL_SEPARATOR+"https://maven.repository.redhat.com/earlyaccess/all";
 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/util/camel/CamelFacetVersionChangeDelegate.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/util/camel/CamelFacetVersionChangeDelegate.java
@@ -32,7 +32,6 @@ import org.eclipse.wst.common.project.facet.core.IDelegate;
 import org.eclipse.wst.common.project.facet.core.IProjectFacetVersion;
 import org.fusesource.ide.camel.model.service.core.catalog.CamelModelFactory;
 import org.fusesource.ide.projecttemplates.internal.ProjectTemplatesActivator;
-import org.fusesource.ide.projecttemplates.preferences.initializer.StagingRepositoriesPreferenceInitializer;
 import org.fusesource.ide.projecttemplates.util.maven.MavenUtils;
 
 public class CamelFacetVersionChangeDelegate implements IDelegate {
@@ -82,13 +81,7 @@ public class CamelFacetVersionChangeDelegate implements IDelegate {
 			MavenUtils.updateContributedPlugins(m2Build.getPlugins(), camelVersion);
 		}
 		
-		if(new StagingRepositoriesPreferenceInitializer().isStagingRepositoriesEnabled()){
-			for(List<String> nameURlPair : new StagingRepositoriesPreferenceInitializer().getStagingRepositories()){
-				String repoURI = nameURlPair.get(1);
-				MavenUtils.ensureRepositoryExists(m2m.getRepositories(), repoURI, nameURlPair.get(0));
-				MavenUtils.ensureRepositoryExists(m2m.getPluginRepositories(), repoURI, nameURlPair.get(0));
-			}
-		}
+		MavenUtils.manageStagingRepositories(m2m);
 		
 		MavenUtils.ensureRepositoryExists(m2m.getRepositories(), REDHAT_GA_PUBLIC_REPO, "redhat-ga-repository");
 		MavenUtils.ensureRepositoryExists(m2m.getPluginRepositories(), REDHAT_GA_PUBLIC_REPO, "redhat-ga-repository");

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/README.md
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/README.md
@@ -1,0 +1,58 @@
+# Spring-Boot Camel XML QuickStart
+
+This example demonstrates how to configure Camel routes in Spring Boot via
+a Spring XML configuration file.
+
+The application utilizes the Spring [`@ImportResource`](http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/context/annotation/ImportResource.html) annotation to load a Camel Context definition via a [camel-context.xml](src/main/resources/spring/camel-context.xml) file on the classpath.
+
+### Building
+
+The example can be built with
+
+    mvn clean install
+
+
+### Running the example locally
+
+The example can be run locally using the following Maven goal:
+
+    mvn spring-boot:run
+
+
+### Running the example on OpenShift from command-line
+
+It is assumed a running OpenShift platform is already running.
+
+Assuming your current shell is connected to OpenShift so that you can type a command like
+
+```
+oc get pods
+```
+
+Then the following command will package your app and run it on OpenShift:
+
+```
+mvn fabric8:run
+```
+
+To list all the running pods:
+
+    oc get pods
+
+Then find the name of the pod that runs this quickstart, and output the logs from the running pods with:
+
+    oc logs <name of pod>
+
+### Running via an S2I Application Template from the command-line
+
+Application templates allow you deploy applications to OpenShift by filling out a form in the OpenShift console that allows you to adjust deployment parameters.  This template uses an S2I source build so that it handles building and deploying the application for you.
+
+First, import the Fuse image streams:
+
+    oc create -f https://raw.githubusercontent.com/jboss-fuse/application-templates/fis-2.0.x.redhat/fis-image-streams.json
+
+Then create the quickstart template:
+
+    oc create -f https://raw.githubusercontent.com/jboss-fuse/application-templates/fis-2.0.x.redhat/quickstarts/spring-boot-camel-xml-template.json
+
+Now when you use the "Add to Project" button in the OpenShift console, you should see a template for this quickstart. 

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/configuration/settings.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/configuration/settings.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2005-2016 Red Hat, Inc.
+
+     Red Hat licenses this file to you under the Apache License, version
+     2.0 (the "License"); you may not use this file except in compliance
+     with the License.  You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+     implied.  See the License for the specific language governing
+     permissions and limitations under the License.
+
+-->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <profiles>
+    <profile>
+      <id>fuse.repos</id>
+
+      <repositories>
+        
+        <repository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        <repository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        
+        <repository>
+          <id>jboss.ea</id>
+          <name>JBoss Early Access Repository</name>
+          <url>http://repository.jboss.org/nexus/content/groups/ea</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        <repository>
+          <id>jboss.brew</id>
+          <name>JBoss Brew Repository</name>
+          <url>http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-common-build/latest/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+        
+        <repository>
+          <id>fis.brew</id>
+          <name>FIS Brew Repository</name>
+          <url>http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-fis-2.0-maven-build/latest/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </repository>
+ 
+      </repositories>
+
+      <pluginRepositories>
+        
+        <pluginRepository>
+          <id>maven.central</id>
+          <name>Maven Central</name>
+          <url>https://repo1.maven.org/maven2</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        <pluginRepository>
+          <id>redhat.ga</id>
+          <name>Red Hat General Availability Repository</name>
+          <url>https://maven.repository.redhat.com/ga</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        
+        <pluginRepository>
+          <id>jboss.ea</id>
+          <name>JBoss Early Access Repository</name>
+          <url>http://repository.jboss.org/nexus/content/groups/ea</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        <pluginRepository>
+          <id>jboss.brew</id>
+          <name>JBoss Brew Repository</name>
+          <url>http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-common-build/latest/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+        
+        <pluginRepository>
+          <id>fis.brew</id>
+          <name>FIS Brew Repository</name>
+          <url>http://download-node-02.eng.bos.redhat.com/brewroot/repos/jb-fis-2.0-maven-build/latest/maven/</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+        </pluginRepository>
+ 
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>fuse.repos</activeProfile>
+  </activeProfiles>
+
+</settings>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/pom.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.mycompany</groupId>
+  <artifactId>camel-ose-springboot-xml</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Fabric8 :: Quickstarts :: Spring-Boot :: Camel XML</name>
+  <description>Spring Boot example running a Camel route defined in XML</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- maven plugin versions -->
+    <fabric8.maven.plugin.version>3.1.80.fuse-000012</fabric8.maven.plugin.version>
+
+    <!-- configure the versions you want to use here -->
+    <fabric8.version>2.2.170.fuse-000011</fabric8.version>
+    <spring-boot.version>1.4.1.RELEASE</spring-boot.version>
+
+    <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>2.19.1</maven-surefire-plugin.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-project-bom-camel-spring-boot</artifactId>
+        <version>${fabric8.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-spring-boot-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+
+    <!-- testing -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>fabric8-arquillian</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <defaultGoal>spring-boot:run</defaultGoal>
+
+    <plugins>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring-boot.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>fabric8-maven-plugin</artifactId>
+        <version>${fabric8.maven.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>resource</goal>
+              <goal>build</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+</project>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/fabric8/deployment.yml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/fabric8/deployment.yml
@@ -1,0 +1,12 @@
+spec:
+  template:
+    spec:
+      containers:
+        - 
+          resources:
+            requests:
+              cpu: "0.2"
+#              memory: 256Mi
+            limits:
+              cpu: "1.0"
+#              memory: 256Mi

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/java/com/mycompany/Application.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/java/com/mycompany/Application.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ * <p>
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.mycompany;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ImportResource;
+
+@SpringBootApplication
+// load regular Spring XML file from the classpath that contains the Camel XML DSL
+@ImportResource({"classpath:spring/camel-context.xml"})
+public class Application {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/java/com/mycompany/MyTransformer.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/java/com/mycompany/MyTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016 Red Hat, Inc.
+ * <p>
+ * Red Hat licenses this file to you under the Apache License, version
+ * 2.0 (the "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.mycompany;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * A sample transform
+ */
+@Component(value = "myTransformer")
+public class MyTransformer {
+
+    public String transform() {
+        // let's return a random string
+        StringBuffer buffer = new StringBuffer();
+        for (int i = 0; i < 3; i++) {
+            int number = (int) (Math.round(Math.random() * 1000) % 10);
+            char letter = (char) ('0' + number);
+            buffer.append(letter);
+        }
+        return buffer.toString();
+    }
+
+}

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/resources/application.properties
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/resources/application.properties
@@ -1,0 +1,17 @@
+#spring.main.sources=com.mycompany
+
+logging.config=classpath:logback.xml
+
+# the options from org.apache.camel.spring.boot.CamelConfigurationProperties can be configured here
+camel.springboot.name=MyCamel
+
+# lets listen on all ports to ensure we can be invoked from the pod IP
+server.address=0.0.0.0
+management.address=0.0.0.0
+
+# lets use a different management port in case you need to listen to HTTP requests on 8080
+management.port=8081
+
+# disable all management endpoints except health
+endpoints.enabled = false
+endpoints.health.enabled = true

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/resources/logback.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/resources/spring/camel-context.xml
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/src/main/resources/spring/camel-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <!-- Define a traditional camel context here -->
+  <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+    <route id="simple-route">
+      <from id="route-timer" uri="timer:foo?period=2000"/>
+      <transform id="route-transform">
+        <method ref="myTransformer"/>
+      </transform>
+      <log id="route-log" message=">>> ${body}"/>
+    </route>
+  </camelContext>
+
+</beans>

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForAMQIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForAMQIT.java
@@ -40,12 +40,14 @@ public class FuseIntegrationProjectCreatorRunnableForAMQIT extends FuseIntegrati
 	public void testAMQBlueprintProjectCreation() throws Exception {
 		//TODO: Known limitations see https://issues.jboss.org/browse/FUSETOOLS-1986
 		assumeFalse("Blueprint with 2.15 redhat version is not working, see https://issues.jboss.org/browse/FUSETOOLS-1986", camelVersion.startsWith("2.15"));
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		
 		testProjectCreation("-AMQBlueprintProject-"+camelVersion, CamelDSLType.BLUEPRINT, "src/main/resources/OSGI-INF/blueprint/camel-blueprint.xml", null);
 	}
 
 	@Test
 	public void testAMQSpringProjectCreation() throws Exception {
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-AMQSpringProject-"+camelVersion, CamelDSLType.SPRING, "src/main/resources/META-INF/spring/camel-context.xml", null);
 	}
 	

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCBRIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCBRIT.java
@@ -39,16 +39,19 @@ public class FuseIntegrationProjectCreatorRunnableForCBRIT  extends FuseIntegrat
 	@Test
 	public void testCBRBluePrintCreation() throws Exception {
 		assumeFalse("Blueprint with 2.15 redhat version is not working, see https://issues.jboss.org/browse/FUSETOOLS-1986", camelVersion.startsWith("2.15"));
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CBRBlueprint-"+camelVersion, CamelDSLType.BLUEPRINT, "src/main/resources/OSGI-INF/blueprint/blueprint.xml", null);
 	}
 		
 	@Test
 	public void testCBRSpringCreation() throws Exception {
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CBRSpring-"+camelVersion, CamelDSLType.SPRING, "src/main/resources/META-INF/spring/camel-context.xml", null);
 	}
 	
 	@Test
 	public void testCBRJavaProjectCreation() throws Exception {
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CBRJavaProject-"+camelVersion, CamelDSLType.JAVA, "src/main/java/com/mycompany/camel/CamelRoute.java", null);
 	}
 	

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT.java
@@ -42,17 +42,20 @@ public class FuseIntegrationProjectCreatorRunnableForCXFCodeFirstIT extends Fuse
 	public void testCXFCodeFirstBlueprintProjectCreation() throws Exception {
 		//TODO: Known limitations see https://issues.jboss.org/browse/FUSETOOLS-1986
 		assumeFalse("Blueprint with 2.15 redhat version is not working, see https://issues.jboss.org/browse/FUSETOOLS-1986", camelVersion.startsWith("2.15"));
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		
 		testProjectCreation("-CXFCodeFirstBlueprintProject", CamelDSLType.BLUEPRINT, "src/main/resources/OSGI-INF/blueprint/blueprint.xml", null);
 	}
 
 	@Test
 	public void testCXFCodeFirstSpringProjectCreation() throws Exception {
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CXFCodeFirstSpringProject-"+camelVersion, CamelDSLType.SPRING, "src/main/resources/META-INF/spring/camel-context.xml", null);
 	}
 	
 	@Test
 	public void testCXFCodeFirstJavaProjectCreation() throws Exception {
+		assumeFalse("2.18.x redhat version is not working, see https://issues.apache.org/jira/browse/CAMEL-10602", camelVersion.startsWith("2.18"));
 		testProjectCreation("-CXFCodeFirstJavaProject-"+camelVersion, CamelDSLType.JAVA, "src/main/java/com/mycompany/camel/cxf/code/first/java/incident/CamelRoute.java", null);
 	}
 	

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForOSESringBootIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForOSESringBootIT.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2016 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ * Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.fusesource.ide.projecttemplates.tests.integration.wizards;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import javax.management.MalformedObjectNameException;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.debug.core.DebugException;
+import org.fusesource.ide.projecttemplates.adopters.util.CamelDSLType;
+import org.fusesource.ide.projecttemplates.impl.simple.OSESpringBootXMLTemplate;
+import org.fusesource.ide.projecttemplates.util.NewProjectMetaData;
+import org.junit.Test;
+
+public class FuseIntegrationProjectCreatorRunnableForOSESringBootIT extends FuseIntegrationProjectCreatorRunnableIT {
+	
+	public FuseIntegrationProjectCreatorRunnableForOSESringBootIT() {
+		camelVersion = "2.18.1";
+	}
+	
+	@Test
+	public void testOSESpringBootProjectCreation() throws Exception {
+        testProjectCreation("-OSESpringBootProject-"+camelVersion, CamelDSLType.SPRING, "src/main/resources/spring/camel-context.xml", null);
+	}
+	
+	@Override
+	protected NewProjectMetaData createDefaultNewProjectMetadata(CamelDSLType dsl, String projectName) {
+		NewProjectMetaData newProjectMetadata = super.createDefaultNewProjectMetadata(dsl, projectName);
+		newProjectMetadata.setTemplate(new OSESpringBootXMLTemplate());
+		newProjectMetadata.setBlankProject(false);
+		return newProjectMetadata;
+	}
+	
+	@Override
+	protected void launchDebug(IProject project) throws InterruptedException, IOException, MalformedObjectNameException, DebugException {
+		// Local launch is not configured for SpringBoot projects
+	}
+	
+	protected void additionalChecks(IProject project) {
+		assertThat(project.findMember("src/main/java/META-INF/MANIFEST.MF")).as("A bad Manifest has been generated").isNull();
+	}
+}

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableIT.java
@@ -83,7 +83,7 @@ import org.junit.rules.TestWatcher;
  * @author Aurelien Pupier
  *
  */
-public class FuseIntegrationProjectCreatorRunnableIT {
+public abstract class FuseIntegrationProjectCreatorRunnableIT {
 
 	public static IProjectFacet camelFacet  = ProjectFacetsManager.getProjectFacet("jst.camel");
 	public static IProjectFacet javaFacet 	= ProjectFacetsManager.getProjectFacet("java");
@@ -120,7 +120,7 @@ public class FuseIntegrationProjectCreatorRunnableIT {
 		PlatformUI.getWorkbench().showPerspective(FusePerspective.ID, page.getWorkbenchWindow());
 		ProjectTemplatesIntegrationTestsActivator.pluginLog().logInfo("Opening Fuse perspective");
 		
-		if("2.17.0.redhat-630187".equals(camelVersion)){
+		if("2.18.1".equals(camelVersion)){
 			new StagingRepositoriesPreferenceInitializer().setStagingRepositoriesEnablement(true);
 		}
 		ProjectTemplatesIntegrationTestsActivator.pluginLog().logInfo("End setup for "+ FuseIntegrationProjectCreatorRunnableIT.class.getSimpleName());
@@ -202,12 +202,16 @@ public class FuseIntegrationProjectCreatorRunnableIT {
 		checkCorrectNatureEnabled(project);
 		checkNoValidationError();
 		checkNoValidationWarning();
+		additionalChecks(project);
 		
 		if(!CamelDSLType.JAVA.equals(dsl)){
 			launchDebug(project);
 		} else {
 			//TODO: different Run? or implement the java local camel context?
 		}
+	}
+
+	protected void additionalChecks(IProject project2) {
 	}
 
 	/**


### PR DESCRIPTION
Provide a basic OpenShift SpringBoot template based on
fabric8-maven-plugin

- templates is based on fuse using fabric8 archetype catalog
2.2.0.fuse-000009
- removed the provided tests as they are not working: see
https://issues.jboss.org/browse/OSFUSE-484
- when new versions of FIS will be available, the template will need to
be updated