### PR TITLE
FUSETOOLS-2153 - Provide pre-configured Launch Configurations

### DIFF
--- a/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/configurators/DefaultTemplateConfigurator.java
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/src/org/fusesource/ide/projecttemplates/adopters/configurators/DefaultTemplateConfigurator.java
@@ -10,7 +10,18 @@
  ******************************************************************************/ 
 package org.fusesource.ide.projecttemplates.adopters.configurators;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.SubMonitor;
@@ -25,20 +36,20 @@ import org.fusesource.ide.projecttemplates.util.camel.CamelFacetDataModelProvide
 import org.fusesource.ide.projecttemplates.util.camel.ICamelFacetDataModelProperties;
 
 /**
- * this configurator does nothing. it just provides additional helper 
+ * this configurator provides additional helper 
  * methods to retrieve a facet data model and to install a facet on the project
  * 
  * @author lhein
  */
 public class DefaultTemplateConfigurator implements TemplateConfiguratorSupport {
-
-	/*
-	 * (non-Javadoc)
-	 * @see org.fusesource.ide.projecttemplates.adopters.configurators.TemplateConfiguratorSupport#configure(org.eclipse.core.resources.IProject, org.fusesource.ide.projecttemplates.util.NewProjectMetaData, org.eclipse.core.runtime.IProgressMonitor)
-	 */
+	
+	private static final String LAUNCH_CONFIGURATION_FILE_EXTENSION = ".launch";
+	private static final String SETTINGS_FUSETOOLING = ".settings/fusetooling";
+	private static final String PLACEHOLDER_PROJECTNAME_IN_LAUNCH_CONFIGURATION = "%%%PLACEHOLDER_PROJECTNAME%%%";
+	
 	@Override
 	public boolean configure(IProject project, NewProjectMetaData metadata, IProgressMonitor monitor) {
-		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.DefaultTemplateConfigurator_ConfiguringJavaProjectMonitorMessage, 8);
+		SubMonitor subMonitor = SubMonitor.convert(monitor, Messages.DefaultTemplateConfigurator_ConfiguringJavaProjectMonitorMessage, 9);
 		IProjectFacetVersion javaFacet = ProjectFacetsManager.getProjectFacet("jst.java").getDefaultVersion(); //$NON-NLS-1$
 		try {
 			// add java facet
@@ -52,11 +63,50 @@ public class DefaultTemplateConfigurator implements TemplateConfiguratorSupport 
 			project.refreshLocal(IProject.DEPTH_INFINITE, subMonitor.newChild(1));
 			project.getFile(".classpath").delete(true, subMonitor.newChild(1)); //$NON-NLS-1$
 			project.refreshLocal(IProject.DEPTH_INFINITE, subMonitor.newChild(1));
+			configureLaunchConfiguration(project, subMonitor.newChild(1));
 		} catch (CoreException ex) {
 			ProjectTemplatesActivator.pluginLog().logError(ex);
 			return false;
 		}
 		return true;
+	}
+
+	private void configureLaunchConfiguration(IProject project, SubMonitor monitor) throws CoreException {
+		IFolder fuseToolingSettingsFolder = project.getFolder(SETTINGS_FUSETOOLING);
+		if(fuseToolingSettingsFolder.exists()){
+			IResource[] potentialLaunchConfigurations = fuseToolingSettingsFolder.members();
+			SubMonitor subMonitor = SubMonitor.convert(monitor, potentialLaunchConfigurations.length + 1);
+			for(IResource potentialLaunchConfiguration : potentialLaunchConfigurations) {
+				if(potentialLaunchConfiguration.getName().endsWith(LAUNCH_CONFIGURATION_FILE_EXTENSION) && potentialLaunchConfiguration instanceof IFile) {
+					replaceInLaunchConfiguration(project, (IFile)potentialLaunchConfiguration);
+				}
+				subMonitor.worked(1);
+			}
+			fuseToolingSettingsFolder.refreshLocal(IResource.DEPTH_ONE, subMonitor.split(1));
+		}
+	}
+
+	private void replaceInLaunchConfiguration(IProject project, IFile launchConfiguration) {
+		Path templateLaunchConfiguration = launchConfiguration.getLocation().toFile().toPath();
+		String projectName = project.getName();
+		String targetFileName = launchConfiguration.getName().replaceAll(PLACEHOLDER_PROJECTNAME_IN_LAUNCH_CONFIGURATION, projectName);
+		Path targetLaunchConfiguration = templateLaunchConfiguration.getParent().resolve(targetFileName);
+		try (Stream<String> lines = Files.lines(templateLaunchConfiguration)) {
+			List<String> replaced = lines
+					.map(line-> line.replaceAll(PLACEHOLDER_PROJECTNAME_IN_LAUNCH_CONFIGURATION, projectName))
+					.collect(Collectors.toList());
+			Files.write(targetLaunchConfiguration, replaced);
+			cleanTemplate(templateLaunchConfiguration);
+		} catch (IOException e) {
+			ProjectTemplatesActivator.pluginLog().logError(e);
+		}
+	}
+
+	private void cleanTemplate(Path templateLaunchConfiguration) {
+		File templateLaunchConfigurationFile = templateLaunchConfiguration.toFile();
+		if(!templateLaunchConfigurationFile.delete()){
+			templateLaunchConfigurationFile.deleteOnExit();
+		}
 	}
 
 	/**

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/.settings/fusetooling/%%%PLACEHOLDER_PROJECTNAME%%% deploy on OpenShift.launch
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/.settings/fusetooling/%%%PLACEHOLDER_PROJECTNAME%%% deploy on OpenShift.launch
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="clean install fabric8:deploy"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dkubernetes.master=https://10.1.2.2:8443&#13;&#10;-Dkubernetes.namespace=test&#13;&#10;-Dkubernetes.auth.basic.username=admin&#13;&#10;-Dkubernetes.auth.basic.password=admin&#13;&#10;-Dfabric8.mode=openshift&#13;&#10;-Dkubernetes.trust.certificates=true&#13;&#10;-Dfabric8.build.strategy=s2i&#13;&#10;-Dkubernetes.auth.tryServiceAccount=false&#13;&#10;-Dfabric8.generator.from=docker-registry.usersys.redhat.com/fabric8/fis-java-openshift:2.0&#13;&#10;-Dkubernetes.auth.tryKubeConfig=false"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:%%%PLACEHOLDER_PROJECTNAME%%%}"/>
+</launchConfiguration>

--- a/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/.settings/fusetooling/Launch locally %%%PLACEHOLDER_PROJECTNAME%%%.launch
+++ b/editor/plugins/org.fusesource.ide.projecttemplates/template-sources/simple/ose/simple-ose-log-springboot/.settings/fusetooling/Launch locally %%%PLACEHOLDER_PROJECTNAME%%%.launch
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.m2e.Maven2LaunchConfigurationType">
+<booleanAttribute key="M2_DEBUG_OUTPUT" value="false"/>
+<stringAttribute key="M2_GOALS" value="spring-boot:run"/>
+<booleanAttribute key="M2_NON_RECURSIVE" value="false"/>
+<booleanAttribute key="M2_OFFLINE" value="false"/>
+<stringAttribute key="M2_PROFILES" value=""/>
+<listAttribute key="M2_PROPERTIES"/>
+<stringAttribute key="M2_RUNTIME" value="EMBEDDED"/>
+<booleanAttribute key="M2_SKIP_TESTS" value="false"/>
+<intAttribute key="M2_THREADS" value="1"/>
+<booleanAttribute key="M2_UPDATE_SNAPSHOTS" value="false"/>
+<stringAttribute key="M2_USER_SETTINGS" value=""/>
+<booleanAttribute key="M2_WORKSPACE_RESOLUTION" value="false"/>
+<stringAttribute key="org.eclipse.jdt.launching.WORKING_DIRECTORY" value="${project_loc:%%%PLACEHOLDER_PROJECTNAME%%%}"/>
+</launchConfiguration>

--- a/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForOSESringBootIT.java
+++ b/editor/tests/org.fusesource.ide.projecttemplates.tests.integration/src/main/java/org/fusesource/ide/projecttemplates/tests/integration/wizards/FuseIntegrationProjectCreatorRunnableForOSESringBootIT.java
@@ -49,5 +49,7 @@ public class FuseIntegrationProjectCreatorRunnableForOSESringBootIT extends Fuse
 	
 	protected void additionalChecks(IProject project) {
 		assertThat(project.findMember("src/main/java/META-INF/MANIFEST.MF")).as("A bad Manifest has been generated").isNull();
+		assertThat(project.getFile(".settings/fusetooling/"+project.getName()+" deploy on OpenShift.launch").getLocation().toFile()).exists();
+		assertThat(project.getFile(".settings/fusetooling/Launch locally "+project.getName()+".launch").getLocation().toFile()).exists();
 	}
 }


### PR DESCRIPTION
- one for launching locally
- one for deploying on OpenShift with mandatory java system properties
pre-filled.

those Launch Configuratiosn are available when doing Run As -> Run configuration...
![image](https://cloud.githubusercontent.com/assets/1105127/21456542/23152fe0-c929-11e6-97ec-b4956faaaedc.png)
for the local one:
![image](https://cloud.githubusercontent.com/assets/1105127/21456572/4d506cac-c929-11e6-85f9-cac65950b89c.png)
For the deployment on OpenShift using fabric8-maven-plugin:
![image](https://cloud.githubusercontent.com/assets/1105127/21456580/61e3dfdc-c929-11e6-8187-406f113cb709.png)
![image](https://cloud.githubusercontent.com/assets/1105127/21456613/b55c47bc-c929-11e6-8595-ae161260277f.png)

- VM arguments are used because fabric8-maven-plugin is not supporting maven properties and environment variables seems to not working neither
