### PR TITLE
FUSETOOLS-2244 - Avoid exception when resource deleted

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/BasicNodeValidator.java
+++ b/core/plugins/org.fusesource.ide.camel.validation/src/org/fusesource/ide/camel/validation/diagram/BasicNodeValidator.java
@@ -113,7 +113,7 @@ public class BasicNodeValidator implements ValidationSupport {
 			final CamelFile camelFile = camelModelElement.getCamelFile();
 			if (camelFile != null) {
 				final IResource resource = camelFile.getResource();
-				if (resource != null) {
+				if (resource != null && resource.exists()) {
 					for (IMarker marker : resource.findMarkers(IFuseMarker.MARKER_TYPE, true, IResource.DEPTH_INFINITE)) {
 						if (camelModelElement.getId() != null && camelModelElement.getId().equals(marker.getAttribute(IFuseMarker.CAMEL_ID))) {
 							res.add(marker);


### PR DESCRIPTION
when a resource is deleted, the Validation Job can still be running. In
this case we can just ignore it, markers are removed by Eclipse system.