### PR TITLE
FUSETOOLS-2240 - Upgrade to JBTIS TP 4.4.1.CR2

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -28,16 +28,14 @@ If you just want to check if things compiles/builds you can run:
     $ mvn clean package -Dmaven.test.skip=true
 
 ## Generating the target platform
-If you want to do development in Eclipse for Fuse Tooling you need to have our target platform mirrored to your local machine so Eclipse can resolve used bundles. Creating the mirror takes quite a while and should only be done if the version of upstream bundles changed. (or the used JBoss Tools Integration Stack version)
+If you want to do development in Eclipse for Fuse Tooling you need to use the JBDS Integration Stack Target Platform.
 
-Here's how to generate the mirror...
+Here's how to retrieve the target files describing the Target Platform...
 
     $ cd fuseide/targetplatform
-    $ mvn -Pmultiple2repo
-       OR
-    $ mvn -Pmultiple2repo -Dmirror-target-to-repo.includeSources=true  (that will include SDKs)
+    $ mvn generate-sources
 
-Once the download is done you end up with a target platform folder inside the *target* subfolder. Now copy this folder to a place you want to keep the target platform mirror and remember the location for the Eclipse Setup below...
+Once the build is done you end up with a file aggregate-*.target older inside the *target/tp* subfolder. Now open this file with Target File editor from Eclipse IDE and click "Set as target Platform" at the top right. Be patient... and it will be ready.
 
 ## Eclipse Setup
 At _master_ branch we always try to use the latest Eclipse version. Please refer to the target platform plugin to see which versions of Eclipse are supported. The _master_ branch was using *Eclipse Luna* when this document was created.
@@ -48,15 +46,6 @@ Here's how to setup Eclipse...
 
 - create a new workspace for working on _JBoss Fuse Tooling_
 - import the project into Eclipse from directory "fuseide" (_Import... -> General -> Existing Project_)
-- open the Eclipse preferences and select *Plug-in Development / Target Platform* in the list.
-- now click the *Add* button and select *Nothing: Start with an empty target platform*
-- click *Next* and give that target platform a name and click the button *Add* in the *Locations* tab
-- choose *Directory* and click *Next*
-- in the location browse dialog click on *Browse* and navigate to your platform mirror folder
-- click *OK* to close the file browser
-- validate that the location in the text field is correct and click *Finish"
-- click *Finish* to close the dialog and then the Eclipse preferences
-- make sure you checked the checkbox in front of your new target platform definition to activate it
 
 Now your Eclipse has set the target platform you need for running _JBoss Fuse Tooling_. A rebuild of all imported projects is done directly after setting the target platform. Make sure there are no more errors displayed in any of the projects.
 
@@ -72,8 +61,9 @@ Before trying to run the Fuse Tooling you should have built the project, importe
 
 To run open the Run Configurations dialog and select one of the following *Eclipse Applications*:
 
-    JBTIS Kepler Linux.launch			# Eclipse Kepler based
-    JBTIS Luna Linux.launch			# Eclipse Luna based
+    JBTIS Neon Linux x86_64.launch			# Eclipse Neon based
+    JBTIS Neon Mac OS.launch			# Eclipse Neon based
+    JBTIS Neon Windows.launch			# Eclipse Neon based
 
 It may be possible that you have to adapt the launch configuration to fit your environment. If your OS doesn't have a launch configuration yet just create one by copying one of the Linux configurations and then inside the _Plugins_ tab make sure to hit the _Add required_ button. That should fix most of the problems.
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- JBoss Tools Integration Stack version -->
-    <jbtis.version>4.4.1.CR1</jbtis.version>
+    <jbtis.version>4.4.1.CR2</jbtis.version>
     <jbtis.classifier>base</jbtis.classifier> <!-- base-ea -->
     
     <!-- Tycho versions -->

--- a/targetplatform/pom.xml
+++ b/targetplatform/pom.xml
@@ -15,6 +15,30 @@
 	<packaging>pom</packaging>
 	<name>JBoss Fuse Tooling :: Target Platform Generation</name>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>com.googlecode.maven-download-plugin</groupId>
+				<artifactId>download-maven-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>download-tp</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>wget</goal>
+						</goals>
+						<configuration>
+							<url>http://download.jboss.org/jbosstools/targetplatforms/jbtistarget/${jbtis.version}/aggregate-${jbtis.classifier}.target</url>
+							<overwrite>true</overwrite>
+							<skipCache>true</skipCache>
+							<outputDirectory>${project.build.directory}/tp</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+	
 	<profiles>
 		<profile>
 			<id>multiple2repo</id>


### PR DESCRIPTION
due to limitations, cannot use anymore a local Target Platform, so
changed to use the .target file provided by JBTIS Target Platform as a
temporary - I hope - workaround.