### PR TITLE
Upgrade to 4.4.2.Final-SNAPSHOT

### DIFF
--- a/changeVersion.sh
+++ b/changeVersion.sh
@@ -90,8 +90,5 @@ find * -name 'feature.xml' | xargs perl -pi -e "s/version=\"$SOURCE_VERSION\"/ve
 # other xml files
 #find * -name '*.xml' | xargs perl -pi -e "s/$SOURCE_VERSION_PATTERN_OSGI/$OSGI_TARGET_VERSION/g"
 
-# replace IDE version
-#perl -pi -e "s/<ide-version>.*<\/ide-version>/<ide-version>$MVN_TARGET_VERSION<\/ide-version>/g" plugins/pom.xml
-
 echo "DONE!"
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>parent</artifactId>
-    <version>4.4.0.Alpha1-SNAPSHOT</version>
+    <version>4.4.2.Final-SNAPSHOT</version>
   </parent>
 
   <groupId>org.fusesource.ide</groupId>
@@ -51,7 +51,6 @@
     <!-- fuse tooling related -->
     <tycho.scmUrl>scm:git:https://github.com/fusesource/fuseide.git</tycho.scmUrl>
     <forge-project-id>ide</forge-project-id>
-    <ide-version>${project.version}</ide-version>
     
     <!-- camel version -->
     <camel.version>2.17.0.redhat-630187</camel.version>


### PR DESCRIPTION
upgrading to corresponding JBTIS TP used, using SNAPSHOT because the non-snapshot artefact is not available on repositories