### PR TITLE
FUSETOOLS-2246 - avoid graphic is disposed

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
@@ -518,7 +518,9 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 		if (getDiagramTypeProvider() != null) {
 			getDiagramTypeProvider().init(diagram != null ? diagram : getDiagramTypeProvider().getDiagram(), getDiagramBehavior());
 		}
-        setPictogramElementsForSelection(null);
+		// Deselect to avoid refresh on a not well handled time by
+		// Graphiti which is disposing Font - see FUSETOOLS-1678 and FUSETOOLS-2246
+		getEditorSite().getSelectionProvider().setSelection(new StructuredSelection());
         GraphicalViewer graphicalViewer = getGraphicalViewer();
 	        
         if (graphicalViewer == null)


### PR DESCRIPTION
The workaround consists in resetting the selection to an empty one to
avoid graphic is disposed.
The current selection is more clearly lost now but it was -
unfortunately - already the case before