### PR TITLE
FUSETOOLS-2218 - Double '&' to have it correctly displayed in native

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/FusePropertySection.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/properties/FusePropertySection.java
@@ -282,7 +282,7 @@ public abstract class FusePropertySection extends AbstractPropertySection {
 	private void addDescriptionAsTooltip(Parameter parameter, Label label) {
 		String description = parameter.getDescription();
 		if (description != null) {
-			label.setToolTipText(description);
+			label.setToolTipText(description.replaceAll("&", "&&"));
 		}
 	}
 


### PR DESCRIPTION
tooltip

![image](https://cloud.githubusercontent.com/assets/1105127/22742833/7b5e7d14-ee18-11e6-9bb0-8a7ac3e0c7c9.png)

