### PR TITLE
FUSETOOLS-1938 - Highlight breakpoint only when the thread is suspended

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/CamelDesignEditor.java
@@ -313,7 +313,7 @@ public class CamelDesignEditor extends DiagramEditor implements ISelectionListen
 					CamelThread t = (CamelThread)firstElement;
 					try {
 						CamelStackFrame stackFrame = (CamelStackFrame)t.getTopStackFrame();
-						if (stackFrame != null) {
+						if (stackFrame != null && stackFrame.isSuspended()) {
 							highlightBreakpointNodeWithID(stackFrame.getEndpointId());	
 						}
 					} catch (DebugException e) {


### PR DESCRIPTION
To write some unit tests, it will require a too big refactor from my point of view.
We don't have yet integration tests about debugging, I created a task for that because I feel that it is a quite big task too. https://issues.jboss.org/browse/FUSETOOLS-2288

If you think that we really need to write those testsbefore merging this PR (and have ideas how to write them) please let me know