### PR TITLE
FUSETOOLS-2287 - Call resume before Disabling debugger

### DIFF
--- a/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugTarget.java
+++ b/editor/plugins/org.fusesource.ide.launcher/src/org/fusesource/ide/launcher/debug/model/CamelDebugTarget.java
@@ -459,8 +459,8 @@ public class CamelDebugTarget extends CamelDebugElement implements IDebugTarget 
 	 */
 	public void disconnect() throws DebugException {
 		if (this.debugger != null) {
-			this.debugger.disableDebugger();
 			this.debugger.resumeAll();
+			this.debugger.disableDebugger();
 			for (CamelThread t : threads.values()){
 				t.terminate();
 			}


### PR DESCRIPTION
it avoids that the debugger is no more available when resume is called
and a stack to be written in logs