### PR TITLE
FUSETOOLS-2268 - Upgrade parent pom to 4.4.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.jboss.tools</groupId>
     <artifactId>parent</artifactId>
-    <version>4.4.0.Alpha1-SNAPSHOT</version>
+    <version>4.4.3.Final</version>
   </parent>
 
   <groupId>org.fusesource.ide</groupId>
@@ -40,7 +40,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- JBoss Tools Integration Stack version -->
-    <jbtis.version>4.4.1.Final</jbtis.version>
+    <jbtis.version>4.4.2.AM1</jbtis.version>
     <jbtis.classifier>base</jbtis.classifier> <!-- base-ea -->
     
     <!-- Tycho versions -->


### PR DESCRIPTION
it introduces a change in qualifiers, it is now using the latest git
commit date instead of the time the build occured