### PR TITLE
FUSETOOLS-2304 - More precise search of Camel Editor

### DIFF
--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DeleteAllEndpointBreakpointsFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DeleteAllEndpointBreakpointsFeature.java
@@ -17,7 +17,6 @@ import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IContext;
 import org.eclipse.graphiti.features.context.ICustomContext;
-import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.fusesource.ide.camel.editor.CamelDesignEditor;
 import org.fusesource.ide.camel.editor.internal.CamelEditorUIActivator;
@@ -33,25 +32,21 @@ import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
 public class DeleteAllEndpointBreakpointsFeature extends DeleteEndpointBreakpointFeature {
 
 	/**
-     * Create a new DeleteAllEndpointBreakpointsFeature.
-     * 
-     * @param fp the feature provider
-     * @param context the context
-     */
-    public DeleteAllEndpointBreakpointsFeature(IFeatureProvider fp) {
-        super(fp);
-    }
-    
-    /*
-     * (non-Javadoc)
-     * @see org.fusesource.ide.camel.editor.features.custom.DeleteEndpointBreakpointFeature#execute(org.eclipse.graphiti.features.context.ICustomContext)
-     */
-    @Override
-    public void execute(ICustomContext context) {
-    	IFile contextFile = getContextFile();
-    	String fileName = contextFile.getName();
-    	String projectName = contextFile.getProject().getName();
-    	IBreakpoint[] bps = CamelDebugUtils.getBreakpointsForContext(fileName, projectName);
+	 * Create a new DeleteAllEndpointBreakpointsFeature.
+	 * 
+	 * @param fp the feature provider
+	 * @param context the context
+	 */
+	public DeleteAllEndpointBreakpointsFeature(IFeatureProvider fp) {
+		super(fp);
+	}
+
+	@Override
+	public void execute(ICustomContext context) {
+		IFile contextFile = getContextFile();
+		String fileName = contextFile.getName();
+		String projectName = contextFile.getProject().getName();
+		IBreakpoint[] bps = CamelDebugUtils.getBreakpointsForContext(fileName, projectName);
 		for (IBreakpoint bp : bps) {
 			AbstractCamelModelElement bo = ((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(((CamelEndpointBreakpoint)bp).getEndpointNodeId());
 			try {
@@ -61,11 +56,13 @@ public class DeleteAllEndpointBreakpointsFeature extends DeleteEndpointBreakpoin
 			} finally {
 				// update the pictogram element
 				PictogramElement[] pes = getFeatureProvider().getAllPictogramElementsForBusinessObject(bo);
-				for (PictogramElement pe : pes) getDiagramBehavior().refreshRenderingDecorators(pe);
+				for (PictogramElement pe : pes){
+					getDiagramBehavior().refreshRenderingDecorators(pe);
+				}
 			}
-        }
-    }
-	
+		}
+	}
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#getName()
 	 */
@@ -73,7 +70,7 @@ public class DeleteAllEndpointBreakpointsFeature extends DeleteEndpointBreakpoin
 	public String getName() {
 		return "Delete all breakpoints";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getDescription()
 	 */
@@ -81,7 +78,7 @@ public class DeleteAllEndpointBreakpointsFeature extends DeleteEndpointBreakpoin
 	public String getDescription() {
 		return "Deletes all breakpoints in the selected context";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getImageId()
 	 */
@@ -89,24 +86,23 @@ public class DeleteAllEndpointBreakpointsFeature extends DeleteEndpointBreakpoin
 	public String getImageId() {
 		return ImageProvider.IMG_GRAYDOT;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#isAvailable(org.eclipse.graphiti.features.context.IContext)
 	 */
 	@Override
 	public boolean isAvailable(IContext context) {
 		IFile contextFile = getContextFile();
-    	String fileName = contextFile.getName();
-    	String projectName = contextFile.getProject().getName();
-    	return CamelDebugUtils.getBreakpointsForContext(fileName, projectName).length>0 && isRouteSelected(context);
+		String fileName = contextFile.getName();
+		String projectName = contextFile.getProject().getName();
+		return CamelDebugUtils.getBreakpointsForContext(fileName, projectName).length>0 && isRouteSelected(context);
 	}
-	
+
 	private boolean isRouteSelected(IContext context) {
 		ICustomContext cc = (ICustomContext) context;
-		PictogramElement _pe = cc.getPictogramElements()[0] instanceof Connection ? ((Connection) cc.getPictogramElements()[0])
-                .getStart().getParent() : cc.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        return bo == null || bo instanceof CamelRouteElement;
+		PictogramElement pe = getPEFromContext(cc);
+		final Object bo = getBusinessObjectForPictogramElement(pe);
+		return bo == null || bo instanceof CamelRouteElement;
 	}
+
 }

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DisableCamelBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/DisableCamelBreakpointFeature.java
@@ -16,7 +16,6 @@ import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IContext;
 import org.eclipse.graphiti.features.context.ICustomContext;
-import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.platform.IDiagramContainer;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -41,104 +40,81 @@ public class DisableCamelBreakpointFeature extends SetEndpointBreakpointFeature 
 	public DisableCamelBreakpointFeature(IFeatureProvider fp) {
 		super(fp);
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.ICustomFeature#execute(org.eclipse.graphiti.features.context.ICustomContext)
-	 */
+
 	@Override
 	public void execute(ICustomContext context) {
-		PictogramElement _pe = context.getPictogramElements()[0] instanceof Connection ? ((Connection) context.getPictogramElements()[0])
-                .getStart().getParent() : context.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-            try {
-            	IFile contextFile = getContextFile();
-            	String fileName = contextFile.getName();
-            	String projectName = contextFile.getProject().getName();
-            	
-            	IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
-            	if (bp != null && bp.isEnabled()) {
-            		bp.setEnabled(false);
-            	}
-            } catch (CoreException e) {
-                final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-                final Shell shell;
-                if (container instanceof CamelDesignEditor) {
-                    shell = ((CamelDesignEditor) container).getEditorSite().getShell();
-                } else {
-                    shell = Display.getCurrent().getActiveShell();
-                }
-                MessageDialog.openError(shell, "Error on enabling breakpoint", e.getStatus().getMessage());
-                return;
-            }
-        }
-        getDiagramBehavior().refreshRenderingDecorators(_pe);
+		PictogramElement _pe = getPEFromContext(context);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			try {
+				IFile contextFile = getContextFile();
+				String fileName = contextFile.getName();
+				String projectName = contextFile.getProject().getName();
+
+				IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
+				if (bp != null && bp.isEnabled()) {
+					bp.setEnabled(false);
+				}
+			} catch (CoreException e) {
+				final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
+				final Shell shell;
+				if (container instanceof CamelDesignEditor) {
+					shell = ((CamelDesignEditor) container).getEditorSite().getShell();
+				} else {
+					shell = Display.getCurrent().getActiveShell();
+				}
+				MessageDialog.openError(shell, "Error on enabling breakpoint", e.getStatus().getMessage());
+				return;
+			}
+		}
+		getDiagramBehavior().refreshRenderingDecorators(_pe);
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#getName()
-	 */
+
 	@Override
 	public String getName() {
 		return "Disable Breakpoint";
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getDescription()
-	 */
+
 	@Override
 	public String getDescription() {
 		return "Disables the breakpoint on the selected endpoint node";
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getImageId()
-	 */
+
 	@Override
 	public String getImageId() {
 		return ImageProvider.IMG_GRAYDOT;
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#isAvailable(org.eclipse.graphiti.features.context.IContext)
-	 */
+
 	@Override
 	public boolean isAvailable(IContext context) {
 		ICustomContext cc = (ICustomContext) context;
-		PictogramElement _pe = cc.getPictogramElements()[0] instanceof Connection ? ((Connection) cc.getPictogramElements()[0])
-                .getStart().getParent() : cc.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-        	IFile contextFile = getContextFile();
-        	String fileName = contextFile.getName();
-        	String projectName = contextFile.getProject().getName();
-        	if (_ep.supportsBreakpoint()) {
-        		IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
-        		try {
-        			return bp != null && bp.isEnabled();
-        		} catch (CoreException ex) {
-        			CamelEditorUIActivator.pluginLog().logError(ex);
-        		}
-        	}
-        }
-        return false;
+		PictogramElement _pe = getPEFromContext(cc);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			IFile contextFile = getContextFile();
+			String fileName = contextFile.getName();
+			String projectName = contextFile.getProject().getName();
+			if (_ep.supportsBreakpoint()) {
+				IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
+				try {
+					return bp != null && bp.isEnabled();
+				} catch (CoreException ex) {
+					CamelEditorUIActivator.pluginLog().logError(ex);
+				}
+			}
+		}
+		return false;
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#canExecute(org.eclipse.graphiti.features.context.ICustomContext)
-	 */
+
 	@Override
 	public boolean canExecute(ICustomContext context) {
 		return isAvailable(context);
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.fusesource.ide.camel.editor.features.custom.SetEndpointBreakpointFeature#hasDoneChanges()
-	 */
+
 	@Override
 	public boolean hasDoneChanges() {
 		return false;

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EditConditionalBreakpoint.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EditConditionalBreakpoint.java
@@ -16,7 +16,6 @@ import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IContext;
 import org.eclipse.graphiti.features.context.ICustomContext;
-import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.widgets.Display;
@@ -39,94 +38,74 @@ public class EditConditionalBreakpoint extends SetConditionalBreakpointFeature {
 	public EditConditionalBreakpoint(IFeatureProvider fp) {
 		super(fp);
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.ICustomFeature#execute(org.eclipse.graphiti.features.context.ICustomContext)
-	 */
+
 	@Override
 	public void execute(ICustomContext context) {
-		PictogramElement _pe = context.getPictogramElements()[0] instanceof Connection ? ((Connection) context.getPictogramElements()[0])
-                .getStart().getParent() : context.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-        	IFile contextFile = getContextFile();
-        	String fileName = contextFile.getName();
-        	String projectName = contextFile.getProject().getName();
-            
-        	// now ask the user to define a condition using a language
-        	IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
-        	if (bp != null && bp instanceof CamelConditionalBreakpoint) {
-        		CamelConditionalBreakpoint ccb = (CamelConditionalBreakpoint)bp;
-        		// TODO: open a dialog for the user to select language and enter the condition - maybe provide a helper for predefined variables
-        		ConditionalBreakpointEditorDialog dlg = new ConditionalBreakpointEditorDialog(Display.getDefault().getActiveShell(), _ep);
-        		dlg.setLanguage(ccb.getLanguage());
-        		dlg.setCondition(ccb.getConditionPredicate());
-        		dlg.setBlockOnOpen(true);
-        		if (Window.OK == dlg.open()) {
-        			String language = dlg.getLanguage();
-        			String condition = dlg.getCondition();
-        			ccb.setConditionPredicate(condition);
-        			ccb.setLanguage(language);
-        			// notify debug framework that this breakpoint has changed
-        			DebugPlugin.getDefault().getBreakpointManager().fireBreakpointChanged(ccb);
-        		}
-        	}
-        }
-        getDiagramBehavior().refreshRenderingDecorators(_pe);
+		PictogramElement _pe = getPEFromContext(context);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			IFile contextFile = getContextFile();
+			String fileName = contextFile.getName();
+			String projectName = contextFile.getProject().getName();
+
+			// now ask the user to define a condition using a language
+			IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
+			if (bp != null && bp instanceof CamelConditionalBreakpoint) {
+				CamelConditionalBreakpoint ccb = (CamelConditionalBreakpoint)bp;
+				// TODO: open a dialog for the user to select language and enter the condition - maybe provide a helper for predefined variables
+				ConditionalBreakpointEditorDialog dlg = new ConditionalBreakpointEditorDialog(Display.getDefault().getActiveShell(), _ep);
+				dlg.setLanguage(ccb.getLanguage());
+				dlg.setCondition(ccb.getConditionPredicate());
+				dlg.setBlockOnOpen(true);
+				if (Window.OK == dlg.open()) {
+					String language = dlg.getLanguage();
+					String condition = dlg.getCondition();
+					ccb.setConditionPredicate(condition);
+					ccb.setLanguage(language);
+					// notify debug framework that this breakpoint has changed
+					DebugPlugin.getDefault().getBreakpointManager().fireBreakpointChanged(ccb);
+				}
+			}
+		}
+		getDiagramBehavior().refreshRenderingDecorators(_pe);
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#getName()
-	 */
+
 	@Override
 	public String getName() {
 		return "Edit Conditional Breakpoint";
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getDescription()
-	 */
+
 	@Override
 	public String getDescription() {
 		return "Modifies a conditional breakpoint on the selected endpoint node";
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getImageId()
-	 */
+
 	@Override
 	public String getImageId() {
 		return ImageProvider.IMG_PROPERTIES_BP;
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#isAvailable(org.eclipse.graphiti.features.context.IContext)
-	 */
+
 	@Override
 	public boolean isAvailable(IContext context) {
 		ICustomContext cc = (ICustomContext) context;
-		PictogramElement _pe = cc.getPictogramElements()[0] instanceof Connection ? ((Connection) cc.getPictogramElements()[0])
-                .getStart().getParent() : cc.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-        	IFile contextFile = getContextFile();
-        	String fileName = contextFile.getName();
-        	String projectName = contextFile.getProject().getName();
-            
-        	// now ask the user to define a condition using a language
-        	IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
-        	return bp != null && bp instanceof CamelConditionalBreakpoint;
-        }
-        return false;
+		PictogramElement _pe = getPEFromContext(cc);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			IFile contextFile = getContextFile();
+			String fileName = contextFile.getName();
+			String projectName = contextFile.getProject().getName();
+
+			// now ask the user to define a condition using a language
+			IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
+			return bp != null && bp instanceof CamelConditionalBreakpoint;
+		}
+		return false;
 	}
-	
-	/* (non-Javadoc)
-	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#canExecute(org.eclipse.graphiti.features.context.ICustomContext)
-	 */
+
 	@Override
 	public boolean canExecute(ICustomContext context) {
 		return isAvailable(context);

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EnableCamelBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/EnableCamelBreakpointFeature.java
@@ -16,7 +16,6 @@ import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IContext;
 import org.eclipse.graphiti.features.context.ICustomContext;
-import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.platform.IDiagramContainer;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -32,7 +31,7 @@ import org.fusesource.ide.launcher.debug.util.CamelDebugUtils;
  * @author lhein
  */
 public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
-	
+
 	/**
 	 * creates the feature
 	 * 
@@ -41,42 +40,41 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
 	public EnableCamelBreakpointFeature(IFeatureProvider fp) {
 		super(fp);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.ICustomFeature#execute(org.eclipse.graphiti.features.context.ICustomContext)
 	 */
 	@Override
 	public void execute(ICustomContext context) {
-		PictogramElement _pe = context.getPictogramElements()[0] instanceof Connection ? ((Connection) context.getPictogramElements()[0])
-                .getStart().getParent() : context.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-            try {
-            	IFile contextFile = getContextFile();
-            	String fileName = contextFile.getName();
-            	String projectName = contextFile.getProject().getName();
-            	
-            	IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
-            	if (bp != null && bp.isEnabled() == false) {
-            		bp.setEnabled(true);
-            	}
-            } catch (CoreException e) {
-                final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-                final Shell shell;
-                if (container instanceof CamelDesignEditor) {
-                    shell = ((CamelDesignEditor) container).getEditorSite().getShell();
-                } else {
-                    shell = Display.getCurrent().getActiveShell();
-                }
-                MessageDialog.openError(shell, "Error on enabling breakpoint", e.getStatus().getMessage());
-                return;
-            }
-        }
-        getDiagramBehavior().refreshRenderingDecorators(_pe);
+		PictogramElement _pe = getPEFromContext(context);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			try {
+				IFile contextFile = getContextFile();
+				String fileName = contextFile.getName();
+				String projectName = contextFile.getProject().getName();
+
+				IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
+				if (bp != null && bp.isEnabled() == false) {
+					bp.setEnabled(true);
+				}
+			} catch (CoreException e) {
+				final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
+				final Shell shell;
+				if (container instanceof CamelDesignEditor) {
+					shell = ((CamelDesignEditor) container).getEditorSite().getShell();
+				} else {
+					shell = Display.getCurrent().getActiveShell();
+				}
+				MessageDialog.openError(shell, "Error on enabling breakpoint", e.getStatus().getMessage());
+				return;
+			}
+		}
+		getDiagramBehavior().refreshRenderingDecorators(_pe);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#getName()
 	 */
@@ -84,7 +82,7 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
 	public String getName() {
 		return "Enable Breakpoint";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getDescription()
 	 */
@@ -92,7 +90,7 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
 	public String getDescription() {
 		return "Enables the breakpoint on the selected endpoint node";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getImageId()
 	 */
@@ -100,34 +98,33 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
 	public String getImageId() {
 		return ImageProvider.IMG_GREENDOT;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#isAvailable(org.eclipse.graphiti.features.context.IContext)
 	 */
 	@Override
 	public boolean isAvailable(IContext context) {
 		ICustomContext cc = (ICustomContext) context;
-		PictogramElement _pe = cc.getPictogramElements()[0] instanceof Connection ? ((Connection) cc.getPictogramElements()[0])
-                .getStart().getParent() : cc.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-        	IFile contextFile = getContextFile();
-        	String fileName = contextFile.getName();
-        	String projectName = contextFile.getProject().getName();
-        	if (_ep.supportsBreakpoint()) {
-        		IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
-        		try {
-        			return bp != null && bp.isEnabled() == false;
-        		} catch (CoreException ex) {
-        			CamelEditorUIActivator.pluginLog().logError(ex);
-        		}
-        	}
-        }
-        return false;
+		PictogramElement _pe = getPEFromContext(cc);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			IFile contextFile = getContextFile();
+			String fileName = contextFile.getName();
+			String projectName = contextFile.getProject().getName();
+			if (_ep.supportsBreakpoint()) {
+				IBreakpoint bp = CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName);
+				try {
+					return bp != null && bp.isEnabled() == false;
+				} catch (CoreException ex) {
+					CamelEditorUIActivator.pluginLog().logError(ex);
+				}
+			}
+		}
+		return false;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#canExecute(org.eclipse.graphiti.features.context.ICustomContext)
 	 */
@@ -135,7 +132,7 @@ public class EnableCamelBreakpointFeature extends SetEndpointBreakpointFeature {
 	public boolean canExecute(ICustomContext context) {
 		return isAvailable(context);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.fusesource.ide.camel.editor.features.custom.SetEndpointBreakpointFeature#hasDoneChanges()
 	 */

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetConditionalBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetConditionalBreakpointFeature.java
@@ -20,7 +20,6 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.graphiti.features.IFeatureProvider;
 import org.eclipse.graphiti.features.context.IContext;
 import org.eclipse.graphiti.features.context.ICustomContext;
-import org.eclipse.graphiti.mm.pictograms.Connection;
 import org.eclipse.graphiti.mm.pictograms.PictogramElement;
 import org.eclipse.graphiti.platform.IDiagramContainer;
 import org.eclipse.jface.dialogs.MessageDialog;
@@ -40,7 +39,7 @@ import org.fusesource.ide.launcher.debug.util.ICamelDebugConstants;
  * @author lhein
  */
 public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeature {
-	
+
 	/**
 	 * creates the feature
 	 * 
@@ -49,86 +48,85 @@ public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeatur
 	public SetConditionalBreakpointFeature(IFeatureProvider fp) {
 		super(fp);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.ICustomFeature#execute(org.eclipse.graphiti.features.context.ICustomContext)
 	 */
 	@Override
 	public void execute(ICustomContext context) {
-		PictogramElement _pe = context.getPictogramElements()[0] instanceof Connection ? ((Connection) context.getPictogramElements()[0])
-                .getStart().getParent() : context.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-        final IResource resource = getResource();
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-            try {
-            	Boolean userWantsUpdate = null;
-            	IFile contextFile = getContextFile();
-            	String fileName = contextFile.getName();
-            	String projectName = contextFile.getProject().getName();
-            	
-            	ConditionalBreakpointEditorDialog dlg = new ConditionalBreakpointEditorDialog(Display.getDefault().getActiveShell(), _ep);
-        		dlg.setBlockOnOpen(true);
-        		if (Window.OK == dlg.open()) {
-        			String language = dlg.getLanguage();
-        			String condition = dlg.getCondition();
-        		
-	            	if (Strings.isBlank(_ep.getRouteContainer().getId()) ||
-	            		Strings.isBlank(_ep.getId()) ) {
-	            		// important ID fields are not yet set - ask the user if we
-	            		// can update those fields for him
-	            		userWantsUpdate = askForIDUpdate(_ep);
+		PictogramElement _pe = getPEFromContext(context);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+		final IResource resource = getResource();
 
-	            		if (userWantsUpdate) {
-	            			// update the context id if needed
-	            			if (Strings.isBlank(_ep.getRouteContainer().getId())) {
-	            				String newContextId = ICamelDebugConstants.PREFIX_CONTEXT_ID + UUID.randomUUID().toString();
-	            				_ep.getRouteContainer().setId(newContextId);
-	            			}
-	            			
-	            			// update the node id if blank
-	            			boolean foundUniqueId = false;
-	            			if (Strings.isBlank(_ep.getId())) {
-	            				String newNodeId = null;
-	            				while (!foundUniqueId) {
-	            					newNodeId = ICamelDebugConstants.PREFIX_NODE_ID + _ep.getNewID();
-	            					// we need to check if the id is really unique in our context
-	            					if (((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(newNodeId) == null) {
-	            						foundUniqueId = true;
-	            					}
-	            				}
-	            				if (Strings.isBlank(newNodeId) == false) {
-	            					_ep.setId(newNodeId);
-	            				} else {
-	            					throw new CoreException(new Status(IStatus.ERROR, CamelEditorUIActivator.PLUGIN_ID, "Unable to determine a unique ID for node " + _ep));
-	            				}
-	            			}
-	            			
-	            			// then do a save
-	            			saveEditor();
-                		}
-            		}
-	            	if (userWantsUpdate == null || userWantsUpdate == true) {
-		            	// finally create the endpoint
-		    			CamelDebugUtils.createAndRegisterConditionalBreakpoint(resource, _ep, projectName, fileName, language, condition);  
-	            	}
-        		}
-            } catch (CoreException e) {
-                final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-                final Shell shell;
-                if (container instanceof CamelDesignEditor) {
-                    shell = ((CamelDesignEditor) container).getEditorSite().getShell();
-                } else {
-                    shell = Display.getCurrent().getActiveShell();
-                }
-                MessageDialog.openError(shell, "Error on adding breakpoint", e.getStatus().getMessage());
-                return;
-            }
-        }
-        getDiagramBehavior().refreshRenderingDecorators(_pe);
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			try {
+				Boolean userWantsUpdate = null;
+				IFile contextFile = getContextFile();
+				String fileName = contextFile.getName();
+				String projectName = contextFile.getProject().getName();
+
+				ConditionalBreakpointEditorDialog dlg = new ConditionalBreakpointEditorDialog(Display.getDefault().getActiveShell(), _ep);
+				dlg.setBlockOnOpen(true);
+				if (Window.OK == dlg.open()) {
+					String language = dlg.getLanguage();
+					String condition = dlg.getCondition();
+
+					if (Strings.isBlank(_ep.getRouteContainer().getId()) ||
+							Strings.isBlank(_ep.getId()) ) {
+						// important ID fields are not yet set - ask the user if we
+						// can update those fields for him
+						userWantsUpdate = askForIDUpdate(_ep);
+
+						if (userWantsUpdate) {
+							// update the context id if needed
+							if (Strings.isBlank(_ep.getRouteContainer().getId())) {
+								String newContextId = ICamelDebugConstants.PREFIX_CONTEXT_ID + UUID.randomUUID().toString();
+								_ep.getRouteContainer().setId(newContextId);
+							}
+
+							// update the node id if blank
+							boolean foundUniqueId = false;
+							if (Strings.isBlank(_ep.getId())) {
+								String newNodeId = null;
+								while (!foundUniqueId) {
+									newNodeId = ICamelDebugConstants.PREFIX_NODE_ID + _ep.getNewID();
+									// we need to check if the id is really unique in our context
+									if (((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(newNodeId) == null) {
+										foundUniqueId = true;
+									}
+								}
+								if (Strings.isBlank(newNodeId) == false) {
+									_ep.setId(newNodeId);
+								} else {
+									throw new CoreException(new Status(IStatus.ERROR, CamelEditorUIActivator.PLUGIN_ID, "Unable to determine a unique ID for node " + _ep));
+								}
+							}
+
+							// then do a save
+							saveEditor();
+						}
+					}
+					if (userWantsUpdate == null || userWantsUpdate == true) {
+						// finally create the endpoint
+						CamelDebugUtils.createAndRegisterConditionalBreakpoint(resource, _ep, projectName, fileName, language, condition);  
+					}
+				}
+			} catch (CoreException e) {
+				final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
+				final Shell shell;
+				if (container instanceof CamelDesignEditor) {
+					shell = ((CamelDesignEditor) container).getEditorSite().getShell();
+				} else {
+					shell = Display.getCurrent().getActiveShell();
+				}
+				MessageDialog.openError(shell, "Error on adding breakpoint", e.getStatus().getMessage());
+				return;
+			}
+		}
+		getDiagramBehavior().refreshRenderingDecorators(_pe);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#getName()
 	 */
@@ -136,7 +134,7 @@ public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeatur
 	public String getName() {
 		return "Set Conditional Breakpoint";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getDescription()
 	 */
@@ -144,7 +142,7 @@ public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeatur
 	public String getDescription() {
 		return "Sets a conditional breakpoint on the selected endpoint node";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getImageId()
 	 */
@@ -152,27 +150,26 @@ public class SetConditionalBreakpointFeature extends SetEndpointBreakpointFeatur
 	public String getImageId() {
 		return ImageProvider.IMG_YELLOWDOT;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#isAvailable(org.eclipse.graphiti.features.context.IContext)
 	 */
 	@Override
 	public boolean isAvailable(IContext context) {
 		ICustomContext cc = (ICustomContext) context;
-		PictogramElement _pe = cc.getPictogramElements()[0] instanceof Connection ? ((Connection) cc.getPictogramElements()[0])
-                .getStart().getParent() : cc.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-        	IFile contextFile = getContextFile();
-        	String fileName = contextFile.getName();
-        	String projectName = contextFile.getProject().getName();
-            return _ep.supportsBreakpoint() && CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName) == null;
-        }
-        return false;
+		PictogramElement _pe = getPEFromContext(cc);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+			IFile contextFile = getContextFile();
+			String fileName = contextFile.getName();
+			String projectName = contextFile.getProject().getName();
+			return _ep.supportsBreakpoint() && CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName) == null;
+		}
+		return false;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#canExecute(org.eclipse.graphiti.features.context.ICustomContext)
 	 */

--- a/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetEndpointBreakpointFeature.java
+++ b/editor/plugins/org.fusesource.ide.camel.editor/src/org/fusesource/ide/camel/editor/features/custom/SetEndpointBreakpointFeature.java
@@ -50,75 +50,75 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	public SetEndpointBreakpointFeature(IFeatureProvider fp) {
 		super(fp);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.ICustomFeature#execute(org.eclipse.graphiti.features.context.ICustomContext)
 	 */
 	@Override
 	public void execute(ICustomContext context) {
 		PictogramElement _pe = context.getPictogramElements()[0] instanceof Connection ? ((Connection) context.getPictogramElements()[0])
-                .getStart().getParent() : context.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-        final IResource resource = getResource();
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-            try {
-            	Boolean userWantsUpdate = null;
-            	IFile contextFile = getContextFile();
-            	String fileName = contextFile.getName();
-            	String projectName = contextFile.getProject().getName();
-            	if (Strings.isBlank(_ep.getRouteContainer().getId()) ||
-            		Strings.isBlank(_ep.getId()) ) {
-            		// important ID fields are not yet set - ask the user if we
-            		// can update those fields for him
-            		userWantsUpdate = askForIDUpdate(_ep);
-            		if (userWantsUpdate) {
-            			// update the context id if needed
-            			if (Strings.isBlank(_ep.getRouteContainer().getId())) {
-            				String newContextId = ICamelDebugConstants.PREFIX_CONTEXT_ID + UUID.randomUUID().toString();
-            				_ep.getRouteContainer().setId(newContextId);
-            			}
-            			
-            			// update the node id if blank
-            			boolean foundUniqueId = false;
-            			if (Strings.isBlank(_ep.getId())) {
-            				String newNodeId = null;
-            				while (!foundUniqueId) {
-            					newNodeId = _ep.getNewID();
-            					// we need to check if the id is really unique in our context
-            					if (((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(newNodeId) == null) {
-            						foundUniqueId = true;
-            					}
-            				}
-            				if (Strings.isBlank(newNodeId) == false) {
-            					_ep.setId(newNodeId);
-            				} else {
-            					throw new CoreException(new Status(IStatus.ERROR, CamelEditorUIActivator.PLUGIN_ID, "Unable to determine a unique ID for node " + _ep));
-            				}
-            			}
-            		}
-            	}
-            	if (userWantsUpdate == null || userWantsUpdate == true) {
-	            	// finally create the endpoint
-	    			CamelDebugUtils.createAndRegisterEndpointBreakpoint(resource, _ep, projectName, fileName);  
-            	}
-            } catch (CoreException e) {
-                final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-                final Shell shell;
-                if (container instanceof CamelDesignEditor) {
-                    shell = ((CamelDesignEditor) container).getEditorSite().getShell();
-                } else {
-                    shell = Display.getCurrent().getActiveShell();
-                }
-                MessageDialog.openError(shell, "Error on adding breakpoint", e.getStatus().getMessage());
-                return;
-            }
-        }
-        getDiagramBehavior().refresh();
-        getDiagramBehavior().refreshRenderingDecorators(_pe);
+				.getStart().getParent() : context.getPictogramElements()[0];
+				final Object bo = getBusinessObjectForPictogramElement(_pe);
+				final IResource resource = getResource();
+
+				if (bo instanceof AbstractCamelModelElement) {
+					AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
+					try {
+						Boolean userWantsUpdate = null;
+						IFile contextFile = getContextFile();
+						String fileName = contextFile.getName();
+						String projectName = contextFile.getProject().getName();
+						if (Strings.isBlank(_ep.getRouteContainer().getId()) ||
+								Strings.isBlank(_ep.getId()) ) {
+							// important ID fields are not yet set - ask the user if we
+							// can update those fields for him
+							userWantsUpdate = askForIDUpdate(_ep);
+							if (userWantsUpdate) {
+								// update the context id if needed
+								if (Strings.isBlank(_ep.getRouteContainer().getId())) {
+									String newContextId = ICamelDebugConstants.PREFIX_CONTEXT_ID + UUID.randomUUID().toString();
+									_ep.getRouteContainer().setId(newContextId);
+								}
+
+								// update the node id if blank
+								boolean foundUniqueId = false;
+								if (Strings.isBlank(_ep.getId())) {
+									String newNodeId = null;
+									while (!foundUniqueId) {
+										newNodeId = _ep.getNewID();
+										// we need to check if the id is really unique in our context
+										if (((CamelDesignEditor)getDiagramBehavior().getDiagramContainer()).getModel().findNode(newNodeId) == null) {
+											foundUniqueId = true;
+										}
+									}
+									if (Strings.isBlank(newNodeId) == false) {
+										_ep.setId(newNodeId);
+									} else {
+										throw new CoreException(new Status(IStatus.ERROR, CamelEditorUIActivator.PLUGIN_ID, "Unable to determine a unique ID for node " + _ep));
+									}
+								}
+							}
+						}
+						if (userWantsUpdate == null || userWantsUpdate == true) {
+							// finally create the endpoint
+							CamelDebugUtils.createAndRegisterEndpointBreakpoint(resource, _ep, projectName, fileName);  
+						}
+					} catch (CoreException e) {
+						final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
+						final Shell shell;
+						if (container instanceof CamelDesignEditor) {
+							shell = ((CamelDesignEditor) container).getEditorSite().getShell();
+						} else {
+							shell = Display.getCurrent().getActiveShell();
+						}
+						MessageDialog.openError(shell, "Error on adding breakpoint", e.getStatus().getMessage());
+						return;
+					}
+				}
+				getDiagramBehavior().refresh();
+				getDiagramBehavior().refreshRenderingDecorators(_pe);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#getName()
 	 */
@@ -126,7 +126,7 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	public String getName() {
 		return "Set Breakpoint";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getDescription()
 	 */
@@ -134,7 +134,7 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	public String getDescription() {
 		return "Sets a breakpoint on the selected endpoint node";
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#getImageId()
 	 */
@@ -142,27 +142,26 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	public String getImageId() {
 		return ImageProvider.IMG_REDDOT;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#isAvailable(org.eclipse.graphiti.features.context.IContext)
 	 */
 	@Override
 	public boolean isAvailable(IContext context) {
 		ICustomContext cc = (ICustomContext) context;
-		PictogramElement _pe = cc.getPictogramElements()[0] instanceof Connection ? ((Connection) cc.getPictogramElements()[0])
-                .getStart().getParent() : cc.getPictogramElements()[0];
-        final Object bo = getBusinessObjectForPictogramElement(_pe);
-       
-        if (bo instanceof AbstractCamelModelElement) {
-        	AbstractCamelModelElement _ep = (AbstractCamelModelElement) bo;
-        	IFile contextFile = getContextFile();
-        	String fileName = contextFile.getName();
-        	String projectName = contextFile.getProject().getName();
-            return _ep.supportsBreakpoint() && CamelDebugUtils.getBreakpointForSelection(_ep.getId(), fileName, projectName) == null;
-        }
-        return false;
+		PictogramElement _pe = getPEFromContext(cc);
+		final Object bo = getBusinessObjectForPictogramElement(_pe);
+
+		if (bo instanceof AbstractCamelModelElement) {
+			AbstractCamelModelElement ep = (AbstractCamelModelElement) bo;
+			IResource contextFile = ep.getCamelFile().getResource();
+			String fileName = contextFile.getName();
+			String projectName = contextFile.getProject().getName();
+			return ep.supportsBreakpoint() && CamelDebugUtils.getBreakpointForSelection(ep.getId(), fileName, projectName) == null;
+		}
+		return false;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.custom.AbstractCustomFeature#canExecute(org.eclipse.graphiti.features.context.ICustomContext)
 	 */
@@ -170,24 +169,26 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	public boolean canExecute(ICustomContext context) {
 		return isAvailable(context);
 	}
-	
+
 	protected IResource getResource() {
-        final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-        if (container instanceof CamelDesignEditor) {
-            return ((CamelDesignEditor) container).getModel().getResource();
-        }
-        return null;
-    }
-	
+		final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
+		if (container instanceof CamelDesignEditor) {
+			return ((CamelDesignEditor) container).getModel().getResource();
+		}
+		return null;
+	}
+
 	protected PictogramElement getPEFromContext(ICustomContext context) {
-		return context.getPictogramElements()[0] instanceof Connection ? ((Connection) context.getPictogramElements()[0])
-                .getStart().getParent() : context.getPictogramElements()[0];
+		return context.getPictogramElements()[0] instanceof Connection ?
+				((Connection) context.getPictogramElements()[0]).getStart().getParent()
+				: context.getPictogramElements()[0];
 	}
-	
+
 	protected IFile getContextFile() {
-		return CamelUtils.getDiagramEditor().asFileEditorInput(CamelUtils.getDiagramEditor().getEditorInput()).getFile();
+		CamelDesignEditor diagramEditor = CamelUtils.getDiagramEditor(getFeatureProvider().getDiagramTypeProvider());
+		return diagramEditor.asFileEditorInput(diagramEditor.getEditorInput()).getFile();
 	}
-	
+
 	/**
 	 * ask the user if we can update some id fields
 	 * 
@@ -196,15 +197,15 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	 */
 	protected boolean askForIDUpdate(AbstractCamelModelElement node) {
 		final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-        final Shell shell;
-        if (container instanceof CamelDesignEditor) {
-            shell = ((CamelDesignEditor) container).getEditorSite().getShell();
-        } else {
-            shell = Display.getCurrent().getActiveShell();
-        }
-        return MessageDialog.openConfirm(shell, "Please confirm...", "Debugging is only possible if the context and the nodes which have breakpoints have a unique ID set. Do you want to generate the ID values now?\n\n(Warning: All changes in the editor will be written to the context file!)");
+		final Shell shell;
+		if (container instanceof CamelDesignEditor) {
+			shell = ((CamelDesignEditor) container).getEditorSite().getShell();
+		} else {
+			shell = Display.getCurrent().getActiveShell();
+		}
+		return MessageDialog.openConfirm(shell, "Please confirm...", "Debugging is only possible if the context and the nodes which have breakpoints have a unique ID set. Do you want to generate the ID values now?\n\n(Warning: All changes in the editor will be written to the context file!)");
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see org.eclipse.graphiti.features.impl.AbstractFeature#hasDoneChanges()
 	 */
@@ -212,15 +213,16 @@ public class SetEndpointBreakpointFeature extends AbstractCustomFeature {
 	public boolean hasDoneChanges() {
 		return false;
 	}
-	
+
 	protected void saveEditor() throws CoreException {
 		final IDiagramContainer container = getDiagramBehavior().getDiagramContainer();
-        CamelDesignEditor editor = null;
+		CamelDesignEditor editor = null;
 		if (container instanceof CamelDesignEditor) {
-            editor = (CamelDesignEditor) container;
-        } else {
-            throw new CoreException(new Status(IStatus.ERROR, CamelEditorUIActivator.PLUGIN_ID, "Can't find the editor to set the breakpoint!"));
-        }
+			editor = (CamelDesignEditor) container;
+		} else {
+			throw new CoreException(new Status(IStatus.ERROR, CamelEditorUIActivator.PLUGIN_ID, "Can't find the editor to set the breakpoint!"));
+		}
 		editor.getParent().doSave(new NullProgressMonitor());
 	}
+
 }


### PR DESCRIPTION
- it should avoid NPE as the editor is retrieved from FeatureProvider
currently in use instead of the "potentially active one"

- factorize code to retrieve PictogramElement from Context of the
request
- replace spaces by tabs