### PR TITLE
FUSETOOLS-2356 - Avoid stack in log for non local IFile

### DIFF
--- a/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelFilesFinder.java
+++ b/core/plugins/org.fusesource.ide.camel.model.service.core/src/org/fusesource/ide/camel/model/service/core/util/CamelFilesFinder.java
@@ -98,7 +98,8 @@ public class CamelFilesFinder {
 	 */
 	public boolean isFuseCamelContentType(IFile ifile) throws CoreException {
 		if( ifile != null
-				&& ifile.isSynchronized(IResource.DEPTH_ZERO)){
+				&& ifile.isSynchronized(IResource.DEPTH_ZERO)
+				&& ifile.isLocal(IResource.DEPTH_ZERO)){
 			IContentDescription contentDescription = ifile.getContentDescription();
 			if(contentDescription != null){
 				String contentTypeId = contentDescription.getContentType().getId();


### PR DESCRIPTION
bad side is that it is using deprecated API but there is no replacement
for it and this is used in getContentDescription so no other choice
(except ignoring the exception but it is even uglier from my point of
view)

Other opinions?