### PR TITLE
FUSETOOLS-2315 - Use relative uri to ensure working in built version

### DIFF
--- a/editor/plugins/org.fusesource.ide.catalogs/plugin.xml
+++ b/editor/plugins/org.fusesource.ide.catalogs/plugin.xml
@@ -5,31 +5,31 @@
     <catalogContribution id="default">
       <uri
           name="http://activemq.apache.org/schema/spring"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/activemq-spring-5.11.0.redhat-620133.xsd" />
+          uri="xsd/fuse/activemq-spring-5.11.0.redhat-620133.xsd" />
       <uri
           name="http://activemq.apache.org/schema/ra"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/activemq-ra-5.11.0.redhat-620133.xsd" />
+          uri="xsd/fuse/activemq-ra-5.11.0.redhat-620133.xsd" />
       <uri
           name="http://camel.apache.org/schema/blueprint"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/camel-blueprint-2.17.3.xsd" />
+          uri="xsd/fuse/camel-blueprint-2.17.3.xsd" />
       <uri
           name="http://camel.apache.org/schema/blueprint/cxf"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/camel-cxf-2.17.3-blueprint.xsd" />
+          uri="xsd/fuse/camel-cxf-2.17.3-blueprint.xsd" />
       <uri
           name="http://camel.apache.org/schema/spring/cxf"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/camel-cxf-2.18.1-spring.xsd" />
+          uri="xsd/fuse/camel-cxf-2.18.1-spring.xsd" />
       <uri
           name="http://camel.apache.org/schema/spring"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/camel-spring-2.18.1.xsd" />
+          uri="xsd/fuse/camel-spring-2.18.1.xsd" />
       <uri
           name="http://camel.apache.org/schema/spring-integration"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/camel-spring-integration-2.18.1.xsd" />
+          uri="xsd/fuse/camel-spring-integration-2.18.1.xsd" />
       <uri
           name="http://camel.apache.org/schema/spring-security"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/camel-spring-security-2.18.1.xsd" />
+          uri="xsd/fuse/camel-spring-security-2.18.1.xsd" />
        <uri
           name="http://www.osgi.org/xmlns/blueprint/v1.0.0"
-          uri="platform:/plugin/org.fusesource.ide.catalogs/xsd/fuse/osgi-blueprint-1.0.0.xsd" />
+          uri="xsd/fuse/osgi-blueprint-1.0.0.xsd" />
     </catalogContribution>
   </extension>
 </plugin>


### PR DESCRIPTION
I referenced the xsd files in extension points as it is done in other places. in JBoss Tools and it is fixing the issue.

Previously it was working only in environment mode.

I don't explain why it was ok for a part of the xsd validation and not for some atttributes.